### PR TITLE
add image flag to be able to inject a specific image into the tests/clusters

### DIFF
--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -44,7 +44,7 @@ const test = program.command('test')
     )
   )
   .action(async ({suite, passthru, image}) => {
-    if(image) { process.env.IMAGE = image }
+    if (image) { process.env.PEPR_IMAGE = image }
     passthru = passthru || []
     switch (suite) {
       case 'unit':  testUnit(passthru)      ; break

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -33,11 +33,18 @@ const test = program.command('test')
   )
   .addOption(
     new Option(
+      "-i, --image <image>",
+      "pepr controller image to use. (e.g. --image=\"pepr:dev\")",
+    ),
+  )
+  .addOption(
+    new Option(
       '-p, --passthru [passthru...]',
       'args to pass to test runner (e.g. --passthru=\'--testNamePattern="testName()"\')'
     )
   )
-  .action(async ({suite, passthru}) => {
+  .action(async ({suite, passthru, image}) => {
+    if(image) { process.env.IMAGE = image }
     passthru = passthru || []
     switch (suite) {
       case 'unit':  testUnit(passthru)      ; break

--- a/_helpers/src/cluster.ts
+++ b/_helpers/src/cluster.ts
@@ -18,7 +18,7 @@ export async function up(name: string = 'pexex-helpers-cluster'): Promise<string
   }).run()
   if (create.exitcode > 0) { throw create }
 
-  if (process.env.IMAGE) {
+  if (process.env.PEPR_IMAGE) {
     const inject = await new Cmd({
       cmd: `k3d image import ${process.env.IMAGE} -c ${name}`,
     }).run()

--- a/_helpers/src/cluster.ts
+++ b/_helpers/src/cluster.ts
@@ -20,7 +20,7 @@ export async function up(name: string = 'pexex-helpers-cluster'): Promise<string
 
   if (process.env.PEPR_IMAGE) {
     const inject = await new Cmd({
-      cmd: `k3d image import ${process.env.IMAGE} -c ${name}`,
+      cmd: `k3d image import ${process.env.PEPR_IMAGE} -c ${name}`,
     }).run()
     if (inject.exitcode > 0) { throw inject }
   }

--- a/_helpers/src/cluster.ts
+++ b/_helpers/src/cluster.ts
@@ -18,6 +18,13 @@ export async function up(name: string = 'pexex-helpers-cluster'): Promise<string
   }).run()
   if (create.exitcode > 0) { throw create }
 
+  if (process.env.IMAGE) {
+    const inject = await new Cmd({
+      cmd: `k3d image import ${process.env.IMAGE} -c ${name}`,
+    }).run()
+    if (inject.exitcode > 0) { throw inject }
+  }
+
   const config = await new Cmd({
     cmd: `k3d kubeconfig write ${name}`
   }).run()

--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -94,7 +94,7 @@ export async function moduleUp({version = "", verbose = false} = {}) {
   await moduleBuild({version, verbose})
 
   if (process.env.IMAGE) {
-    cmd = `npx --yes pepr@${version} deploy --image=${process.env.IMAGE}--confirm`
+    cmd = `npx --yes pepr@${version} deploy --image=${process.env.IMAGE} --confirm`
   } else {
     cmd = `npx --yes pepr@${version} deploy --confirm`
   }

--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -94,7 +94,7 @@ export async function moduleUp({version = "", verbose = false} = {}) {
   await moduleBuild({version, verbose})
 
   if (process.env.IMAGE) {
-    cmd = `npx --yes pepr@${version} deploy --image=${process.env.IMAGE} --confirm`
+    cmd = `npx --yes pepr@${version} deploy --image=${process.env.PEPR_IMAGE} --confirm`
   } else {
     cmd = `npx --yes pepr@${version} deploy --confirm`
   }

--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -82,6 +82,7 @@ export async function moduleBuild({version = "", verbose = false} = {}) {
 }
 
 export async function moduleUp({version = "", verbose = false} = {}) {
+  let cmd: string = "";
   // can't have await expressions in default args, so gotta do it here
   if (version === ""){ version = await peprVersion()}
 
@@ -92,7 +93,12 @@ export async function moduleUp({version = "", verbose = false} = {}) {
 
   await moduleBuild({version, verbose})
 
-  let cmd = `npx --yes pepr@${version} deploy --confirm`
+  if (process.env.IMAGE) {
+    cmd = `npx --yes pepr@${version} deploy --image=${process.env.IMAGE}--confirm`
+  } else {
+    cmd = `npx --yes pepr@${version} deploy --confirm`
+  }
+
   console.time(cmd)
   const deploy = await new Cmd({env: pepr, cmd}).run()
   if (verbose) { console.log(deploy) }

--- a/hello-pepr-reconcile/capabilities/reconcile.e2e.test.ts
+++ b/hello-pepr-reconcile/capabilities/reconcile.e2e.test.ts
@@ -10,10 +10,10 @@ const trc = new TestRunCfg(__filename);
 
 describe("reconcile.ts", () => {
   beforeAll(async () => await moduleUp(), mins(2));
-  // afterAll(async () => {
-  //   await moduleDown()
-  //   await clean(trc)
-  // }, mins(2))
+  afterAll(async () => {
+    await moduleDown()
+    await clean(trc)
+  }, mins(2))
 
   describe("tests reconcile module", () => {
     let logz: string[]

--- a/hello-pepr-reconcile/capabilities/reconcile.e2e.test.ts
+++ b/hello-pepr-reconcile/capabilities/reconcile.e2e.test.ts
@@ -10,10 +10,10 @@ const trc = new TestRunCfg(__filename);
 
 describe("reconcile.ts", () => {
   beforeAll(async () => await moduleUp(), mins(2));
-  afterAll(async () => {
-    await moduleDown()
-    await clean(trc)
-  }, mins(2))
+  // afterAll(async () => {
+  //   await moduleDown()
+  //   await clean(trc)
+  // }, mins(2))
 
   describe("tests reconcile module", () => {
     let logz: string[]


### PR DESCRIPTION
This adds the ability to inject a custom image into the clusters which allows us to run the tests from Pepr Core against a development image.

Usage:

```plaintext
npm run test:e2e -- -i pepr:dev
```