### PR TITLE
chore: no parse options

### DIFF
--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -10,7 +10,7 @@ import { readFile } from 'node:fs/promises';
 function sift(stdout) {
   try {
     const parsed = stdout
-      .filter(l => l !== '')
+      .filter(l => l !== '' && !l.includes('DEP0040')  && !l.includes('--trace-deprecation'))
       .map(l => JSON.parse(l))
       .filter(l => l)
       .filter(l => l.url !== "/healthz")

--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -10,7 +10,7 @@ import { readFile } from 'node:fs/promises';
 function sift(stdout) {
   try {
     const parsed = stdout
-      .filter(l => l !== '' && !l.includes('DEP0040')  && !l.includes('--trace-deprecation'))
+      .filter(l => l !== '' && !l.includes('] DeprecationWarning: ')  && !l.includes('--trace-deprecation'))
       .map(l => JSON.parse(l))
       .filter(l => l)
       .filter(l => l.url !== "/healthz")


### PR DESCRIPTION
Does not attempt to parse around deprecations.

The sift command is creating errors in our CI when the deprecation is being parse. I want to filter those lines before the parse.

```json
 '(node:1) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.',
      '(Use `node --trace-deprecation ...` to show where the warning was created)',
 ```
 
 [Link](https://github.com/defenseunicorns/pepr/actions/runs/10800262187/job/29957921369)