### PR TITLE
fix(testing): derive pepr version from package.json in test

### DIFF
--- a/test-specific-version/capabilities/versions.e2e.test.ts
+++ b/test-specific-version/capabilities/versions.e2e.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect} from "@jest/globals";
 import { execSync } from "child_process";
 import {getPeprAlias} from '../../_helpers/src/pepr'
-import { existsSync, readdirSync, rmdirSync, rmSync, statfsSync } from "fs";
+import { existsSync, readFileSync, rmSync } from "fs";
 
 describe('version tests', () => {
-  const examplePeprVersion = '0.31.1'
+  const examplePeprVersion = getPeprVersionFromBackup()
   const localDevelopmentPeprVersion = '0.0.0-development'
 
   describe(`when pepr version is defined the example's package.json (v${examplePeprVersion})`, () => { 
@@ -27,3 +27,8 @@ describe('version tests', () => {
     })
   })
 })
+
+function getPeprVersionFromBackup() {
+  const packageJson = JSON.parse(readFileSync('package.json.bak', 'utf8'));
+  return packageJson.dependencies?.pepr ? packageJson.dependencies.pepr : 'ERR_PACKAGE_IMPORT_NOT_DEFINED'
+}


### PR DESCRIPTION
This PR accounts for dependabot upgrades to package.json files by reading the pepr version from package.json during E2E version tests.