### PR TITLE
chore: update pepr-excellent-examples examples' devDependencies from CI workflow

### DIFF
--- a/.github/workflows/devDeps.yml
+++ b/.github/workflows/devDeps.yml
@@ -1,0 +1,64 @@
+name: Update devDependencies
+
+permissions: read-all
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '30 4 * * *' # 12:30AM ET/9:30PM PT
+  # push:
+  #   branches: ["main"]
+  # pull_request:
+  #   branches: ["main"]
+
+jobs:
+  refresh:
+    name: update devDependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - name: clone pepr
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          repository: defenseunicorns/pepr
+          path: pepr
+
+      - name: "set env: PEPR"
+        run: echo "PEPR=${GITHUB_WORKSPACE}/pepr" >> "$GITHUB_ENV"
+
+      - name: clone pepr-excellent-examples
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          repository: defenseunicorns/pepr-excellent-examples
+          path: pepr-excellent-examples
+
+      - name: "set env: PEPR_EXEX"
+        run: echo "PEPR_EXEX=${GITHUB_WORKSPACE}/pepr-excellent-examples" >> "$GITHUB_ENV"
+
+      - name: setup node
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: pepr
+
+      - name: create module (pepr init)
+        run: |
+          cd "$PEPR"
+          npx pepr init \
+            --name "pepr-test-module" \
+            --description "for comparing devDependencies against" \
+            --skip-post-init \
+            --confirm
+
+      - name: "set env: PEPR_MOD"
+        run: echo "PEPR_MOD=${PEPR}/pepr-test-module" >> "$GITHUB_ENV"
+
+      - name: check for updates
+        run: |
+          cd "$PEPR_EXEX"
+          npm ci
+          npm run --workspaces cli -- deps "${PEPR_MOD}/package.json"


### PR DESCRIPTION
Follow on work to use the new devDependency update helper ( created in this [PR](https://github.com/defenseunicorns/pepr-excellent-examples/pull/152) ) in a job on CI.

Desire is for a scheduled (nightly) job to submit a PR to update the excellent examples modules' devDependencies -- similar to the way dependabot is suggesting updates via PR to the regular deps.