### PR TITLE
Display accurate version of pepr in test logs

### DIFF
--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -86,7 +86,7 @@ export async function peprVersion() {
   // determine npx pepr@version from workspace root
   const root = (await new Cmd({ cmd: `npm root` }).run()).stdout[0]
   const workspace = dirname(root)
-  const version = (await new Cmd({ cwd: workspace, cmd: `npm run pepr -- --version` }).run())
+  const version = (await new Cmd({ cwd: workspace, cmd: `npx pepr --version` }).run())
     .stdout.filter(l => l !== '').slice(-1)[0]
 
   return version

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "pepr-excellent-examples",
   "license": "Apache-2.0",
   "scripts": {
-    "pepr": "npx pepr@0.36.0",
     "test:e2e": "npm run --workspaces test:e2e"
   },
   "workspaces": [


### PR DESCRIPTION
I noticed a mismatch between reported pepr versions in the test logs. This PR fixes that mismatch.


Note how the example below reports `0.37.2` and `0.36.0` as in use during the same test run.

Example:
```
❯ npm run test:e2e -w hello-pepr-store

[...]

Pepr Version under test: 0.37.2

Pepr Image under test: sha256:deba991c2df63ab0099de55f5440703d2d17d6ebe635595badf0bc7d04715cbe [pepr:dev]

[...]

  console.time
    pepr@0.36.0 ready (total time): 32814 ms

      at moduleUp (../_helpers/src/pepr.ts:133:11)
```