### PR TITLE
feat: add ability to exit Finalize() callback WITHOUT removing the finalizer 

### DIFF
--- a/_helpers/src/Cmd.ts
+++ b/_helpers/src/Cmd.ts
@@ -32,7 +32,8 @@ export class Cmd {
     return new Promise((resolve) => {
       const proc = exec(this.cmd, {
         cwd: this.cwd,
-        env: this.env as NodeJS.ProcessEnv
+        env: this.env as NodeJS.ProcessEnv,
+        maxBuffer: 1024 * 1024 * 100 // 100MiB
       })
 
       this.stdin.forEach(line => proc.stdin.write(`${line}\n`))

--- a/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
+++ b/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
@@ -18,7 +18,7 @@ describe("finalize.ts", () => {
   describe("create", () => {
     let logz: string[]
 
-     beforeAll(async () => {
+    beforeAll(async () => {
       const file = `${trc.root()}/capabilities/scenario.create.yaml`;
       await timed(`load: ${file}`, async () => {
         let [ ns, cmReconcile, cmWatch ] = await trc.load(file)
@@ -47,7 +47,7 @@ describe("finalize.ts", () => {
   describe("createorupdate", () => {
     let logz: string[]
 
-     beforeAll(async () => {
+    beforeAll(async () => {
       const file = `${trc.root()}/capabilities/scenario.create-or-update.yaml`;
       await timed(`load: ${file}`, async () => {
         let [ ns, cmWatch ] = await trc.load(file)
@@ -79,7 +79,7 @@ describe("finalize.ts", () => {
   describe("update", () => {
     let logz: string[]
 
-     beforeAll(async () => {
+    beforeAll(async () => {
       const file = `${trc.root()}/capabilities/scenario.update.yaml`;
       await timed(`load: ${file}`, async () => {
         let [ ns, cmWatch ] = await trc.load(file)
@@ -107,10 +107,41 @@ describe("finalize.ts", () => {
     }, secs(10));
   });
 
+  describe.skip("update, opt out of removing finalizer", () => {
+    // let logz: string[]
+
+    // beforeAll(async () => {
+    //   const file = `${trc.root()}/capabilities/scenario.update.yaml`;
+    //   await timed(`load: ${file}`, async () => {
+    //     let [ ns, cmWatch ] = await trc.load(file)
+    //     await fullCreate([ns, cmWatch])
+
+    //     await K8s(kind[cmWatch.kind]).Apply({...cmWatch, data: { note: "updated"}})
+    //     await K8s(kind[cmWatch.kind]).Delete(cmWatch)
+
+    //     await untilLogged("Removed finalizer 'pepr.dev/finalizer' from 'hello-pepr-finalize-update/")
+    //     logz = await logs();
+    //   });
+    // }, mins(2));
+
+    // it("triggers action and finalizer callbacks", async () => {
+    //   let results = logz.filter(l => l.includes('"msg":"external api call (update):'))
+      
+    //   let wants = [
+    //     "watch/callback",
+    //     "watch/finalize",
+    //   ]
+    //   wants.forEach((wanted, atIndex) => {
+    //     expect(results[atIndex]).toContain(wanted)
+    //   })
+
+    // }, secs(10));
+  });
+
   describe("delete", () => {
     let logz: string[]
 
-     beforeAll(async () => {
+    beforeAll(async () => {
       const file = `${trc.root()}/capabilities/scenario.delete.yaml`;
       await timed(`load: ${file}`, async () => {
         let [ ns, cmWatch ] = await trc.load(file)

--- a/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
+++ b/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
@@ -5,6 +5,7 @@ import { fullCreate } from "helpers/src/general";
 import { moduleUp, moduleDown, untilLogged, logs } from "helpers/src/pepr";
 import { clean } from "helpers/src/cluster";
 import { K8s, kind } from "pepr";
+import { KubernetesObject } from "kubernetes-fluent-client";
 
 const trc = new TestRunCfg(__filename);
 
@@ -107,35 +108,54 @@ describe("finalize.ts", () => {
     }, secs(10));
   });
 
-  describe.skip("update, opt out of removing finalizer", () => {
-    // let logz: string[]
+  describe("update, opt out of removing finalizer", () => {
+    let logz: string[]
+    let ns, cmWatch;
 
-    // beforeAll(async () => {
-    //   const file = `${trc.root()}/capabilities/scenario.update.yaml`;
-    //   await timed(`load: ${file}`, async () => {
-    //     let [ ns, cmWatch ] = await trc.load(file)
-    //     await fullCreate([ns, cmWatch])
+    beforeAll(async () => {
+      const file = `${trc.root()}/capabilities/scenario.update.opt-out.yaml`;
+      await timed(`load: ${file}`, async () => {
+        [ ns, cmWatch ] = await trc.load(file)
+        await fullCreate([ns, cmWatch])
 
-    //     await K8s(kind[cmWatch.kind]).Apply({...cmWatch, data: { note: "updated"}})
-    //     await K8s(kind[cmWatch.kind]).Delete(cmWatch)
+        await K8s(kind[cmWatch.kind]).Apply({...cmWatch, data: { note: "updated"}})
+        await K8s(kind[cmWatch.kind]).Delete(cmWatch)
 
-    //     await untilLogged("Removed finalizer 'pepr.dev/finalizer' from 'hello-pepr-finalize-update/")
-    //     logz = await logs();
-    //   });
-    // }, mins(2));
+        await untilLogged("Skip removal of finalizer 'pepr.dev/finalizer' from 'hello-pepr-finalize-update-opt-out/")
 
-    // it("triggers action and finalizer callbacks", async () => {
-    //   let results = logz.filter(l => l.includes('"msg":"external api call (update):'))
-      
-    //   let wants = [
-    //     "watch/callback",
-    //     "watch/finalize",
-    //   ]
-    //   wants.forEach((wanted, atIndex) => {
-    //     expect(results[atIndex]).toContain(wanted)
-    //   })
+        logz = await logs();
+      });
+    }, mins(2));
 
-    // }, secs(10));
+    it("triggers action and finalizer callbacks but skips removing finalizer", async () => {
+      let results = logz.filter(l => l.includes('"msg":"external api call (update-opt-out):'))
+
+      let wants = [
+        "watch/callback",
+        "watch/pre-finalize",
+      ]
+      wants.forEach((wanted, atIndex) => {
+        expect(results[atIndex]).toContain(wanted)
+      })
+
+      // pull fresh resource (to verify that finalizer still exists)
+      let resource: KubernetesObject = await K8s(kind[cmWatch.kind])
+        .InNamespace(cmWatch.metadata.namespace)
+        .Get(cmWatch.metadata.name);
+
+      // clear finalizers so that cleanup won't get blocked
+      await K8s(kind[cmWatch.kind], {
+        namespace: cmWatch.metadata.namespace,
+        name: cmWatch.metadata.name,
+      }).Patch([{
+        op: "replace",
+        path: `/metadata/finalizers`,
+        value: [],
+      }]);
+
+      // assert AFTER finalizer is cleared so that cleanup doesn't hang in failure case
+      expect(resource.metadata?.finalizers).toEqual(['pepr.dev/finalizer'])
+    }, secs(10));
   });
 
   describe("delete", () => {

--- a/hello-pepr-finalize/capabilities/finalize.ts
+++ b/hello-pepr-finalize/capabilities/finalize.ts
@@ -7,6 +7,7 @@ export const HelloPeprFinalize = new Capability({
     "hello-pepr-finalize-create",
     "hello-pepr-finalize-createorupdate",
     "hello-pepr-finalize-update",
+    "hello-pepr-finalize-update-opt-out",
     "hello-pepr-finalize-delete",
   ],
 });
@@ -61,6 +62,21 @@ When(a.ConfigMap)
   })
   .Finalize(function finalizeUpdate(cm) {
     Log.info(cm, "external api call (update): watch/finalize")
+  });
+
+  When(a.ConfigMap)
+  .IsUpdated()
+  .InNamespace("hello-pepr-finalize-update-opt-out")
+  .WithName("cm-watch-update-opt-out")
+  .Watch(function watchUpdateOptOut(cm) {
+    // delete with finalizer triggers an UPDATE to add deletionTimestamp; ignore it
+    if (cm.metadata?.deletionTimestamp) { return }
+
+    Log.info(cm, "external api call (update-opt-out): watch/callback")
+  })
+  .Finalize(function finalizeUpdateOptOut(cm) {
+    Log.info(cm, "external api call (update-opt-out): watch/pre-finalize")
+    return false;
   });
 
   When(a.ConfigMap)

--- a/hello-pepr-finalize/capabilities/scenario.update.opt-out.yaml
+++ b/hello-pepr-finalize/capabilities/scenario.update.opt-out.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hello-pepr-finalize-update-opt-out
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-watch-update-opt-out
+  namespace: hello-pepr-finalize-update-opt-out
+data: {}


### PR DESCRIPTION
## Description

Adds ability for Module Author to "opt out" of removing Pepr's metadata.finalizers entry.

## Related Issue

Relates [#1316 ](https://github.com/defenseunicorns/pepr/issues/1316)