### PR TITLE
Revert "chore(deps): update dependency typescript to v5.7.2"

### DIFF
--- a/_helpers/package.json
+++ b/_helpers/package.json
@@ -16,7 +16,7 @@
     "kubernetes-fluent-client": "^3.3.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typescript": "5.7.2",
+    "typescript": "5.3.3",
     "yaml": "^2.6.0"
   },
   "scripts": {

--- a/dash-policyreport/package.json
+++ b/dash-policyreport/package.json
@@ -35,7 +35,7 @@
     "kubernetes-fluent-client": "^3.3.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typescript": "5.7.2",
+    "typescript": "5.3.3",
     "yaml": "2.6.0"
   },
   "scripts": {

--- a/hello-pepr-alias/package.json
+++ b/hello-pepr-alias/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-config-ignored-ns/package.json
+++ b/hello-pepr-config-ignored-ns/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-config/package.json
+++ b/hello-pepr-config/package.json
@@ -40,7 +40,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-custom-rbac/package.json
+++ b/hello-pepr-custom-rbac/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-deletion-timestamp/package.json
+++ b/hello-pepr-deletion-timestamp/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-finalize/package.json
+++ b/hello-pepr-finalize/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-hooks/package.json
+++ b/hello-pepr-hooks/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-load/package.json
+++ b/hello-pepr-load/package.json
@@ -35,7 +35,7 @@
     "pepr": "^0.42.0"
   },
   "devDependencies": {
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-mutate/package.json
+++ b/hello-pepr-mutate/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-ns-all/package.json
+++ b/hello-pepr-ns-all/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-ns-bounded/package.json
+++ b/hello-pepr-ns-bounded/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-ns-wrong/package.json
+++ b/hello-pepr-ns-wrong/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-onschedule/package.json
+++ b/hello-pepr-onschedule/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-reconcile-global/package.json
+++ b/hello-pepr-reconcile-global/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-reconcile-kind/package.json
+++ b/hello-pepr-reconcile-kind/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-reconcile-kindns/package.json
+++ b/hello-pepr-reconcile-kindns/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-reconcile-kindnsname/package.json
+++ b/hello-pepr-reconcile-kindnsname/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-regex-name/package.json
+++ b/hello-pepr-regex-name/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-regex-ns-all/package.json
+++ b/hello-pepr-regex-ns-all/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-regex-ns-bounded/package.json
+++ b/hello-pepr-regex-ns-bounded/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-regex-ns-wrong/package.json
+++ b/hello-pepr-regex-ns-wrong/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-soak/package.json
+++ b/hello-pepr-soak/package.json
@@ -33,7 +33,7 @@
     "pepr": "^0.42.0"
   },
   "devDependencies": {
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "cli": "npm run --workspace helpers cli -- --module=$(pwd)",

--- a/hello-pepr-store-redact-logs/package.json
+++ b/hello-pepr-store-redact-logs/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-store/package.json
+++ b/hello-pepr-store/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-validate/package.json
+++ b/hello-pepr-validate/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr-watch/package.json
+++ b/hello-pepr-watch/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^22.9.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",

--- a/hello-pepr/package.json
+++ b/hello-pepr/package.json
@@ -25,7 +25,7 @@
     "pepr": "^0.42.0"
   },
   "devDependencies": {
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "cli": "npm run --workspace helpers cli -- --module=$(pwd)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,22 +55,8 @@
         "kubernetes-fluent-client": "^3.3.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "typescript": "5.7.2",
+        "typescript": "5.3.3",
         "yaml": "^2.6.0"
-      }
-    },
-    "_helpers/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "dash-policyreport": {
@@ -88,25 +74,11 @@
         "kubernetes-fluent-client": "^3.3.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
-        "typescript": "5.7.2",
+        "typescript": "5.3.3",
         "yaml": "2.6.0"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "dash-policyreport/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr": {
@@ -115,7 +87,7 @@
         "pepr": "^0.42.0"
       },
       "devDependencies": {
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -131,24 +103,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-alias/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-config": {
@@ -161,7 +119,7 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -177,38 +135,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-config-ignored-ns/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "hello-pepr-config/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-custom-rbac": {
@@ -221,24 +151,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-custom-rbac/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-deletion-timestamp": {
@@ -251,24 +167,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-deletion-timestamp/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-finalize": {
@@ -281,24 +183,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-finalize/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-hooks": {
@@ -311,24 +199,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-hooks/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-mutate": {
@@ -341,24 +215,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-mutate/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-ns-all": {
@@ -371,24 +231,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-ns-all/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-ns-bounded": {
@@ -401,24 +247,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-ns-bounded/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-ns-wrong": {
@@ -431,24 +263,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-ns-wrong/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-onschedule": {
@@ -461,24 +279,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-onschedule/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-reconcile-global": {
@@ -491,24 +295,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-reconcile-global/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-reconcile-kind": {
@@ -521,24 +311,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-reconcile-kind/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-reconcile-kindns": {
@@ -551,24 +327,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-reconcile-kindns/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-reconcile-kindnsname": {
@@ -581,24 +343,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-reconcile-kindnsname/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-regex-name": {
@@ -611,24 +359,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-regex-name/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-regex-ns-all": {
@@ -641,24 +375,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-regex-ns-all/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-regex-ns-bounded": {
@@ -671,24 +391,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-regex-ns-bounded/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-regex-ns-wrong": {
@@ -701,24 +407,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-regex-ns-wrong/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-soak": {
@@ -727,24 +419,10 @@
         "pepr": "^0.42.0"
       },
       "devDependencies": {
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-soak/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-store": {
@@ -757,7 +435,7 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -773,38 +451,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-store-redact-logs/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "hello-pepr-store/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-validate": {
@@ -817,24 +467,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-validate/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "hello-pepr-watch": {
@@ -849,38 +485,10 @@
         "@types/node": "^22.9.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-watch/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "hello-pepr/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8718,8 +8326,6 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9114,24 +8720,10 @@
         "pepr": "^0.42.0"
       },
       "devDependencies": {
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "pepr-operator/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "test-specific-version": {
@@ -9145,24 +8737,10 @@
         "find-up": "^7.0.0",
         "jest": "^29.7.0",
         "kubernetes-fluent-client": "^3.3.0",
-        "typescript": "5.7.2"
+        "typescript": "5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "test-specific-version/node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     }
   }

--- a/pepr-operator/package.json
+++ b/pepr-operator/package.json
@@ -27,7 +27,7 @@
     "pepr": "^0.42.0"
   },
   "devDependencies": {
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "cli": "npm run --workspace helpers cli -- --module=$(pwd)",

--- a/test-specific-version/package.json
+++ b/test-specific-version/package.json
@@ -37,7 +37,7 @@
     "find-up": "^7.0.0",
     "jest": "^29.7.0",
     "kubernetes-fluent-client": "^3.3.0",
-    "typescript": "5.7.2"
+    "typescript": "5.3.3"
   },
   "scripts": {
     "pepr": "pepr",


### PR DESCRIPTION
Reverts defenseunicorns/pepr-excellent-examples#188

We will only using dependabot going forward, this PR creates an untested TypeScript version in the modules. We have created an issue in Pepr to address this and we will need to soak in UDS Core first to ensure there are no consequences.

https://github.com/defenseunicorns/pepr/issues/1567