### PR TITLE
test: fix silly early-return syntax mistake

### DIFF
--- a/.github/workflows/devDeps.yml
+++ b/.github/workflows/devDeps.yml
@@ -73,7 +73,7 @@ jobs:
       - name: package-lock.json
         run: |
           cd "$PEPR_EXEX"
-          if git diff --quiet ; then return ; fi
+          if git diff --quiet ; then exit 0 ; fi
           
           # npm install removes resolved and integrity properties from package-lock.json if installed from cache
           # https://github.com/npm/cli/issues/4263


### PR DESCRIPTION
Update job is failing in CI _when no updates are required_.

This is happening because of a call to `return` (which _would_ be fine if this logic was being run in a function, but it's not) from the top-level scope of the CI script.

This PR just swaps an invocation of `exit 0` in where the early return is required.