### PR TITLE
chore: add new failure message case

### DIFF
--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -27,7 +27,8 @@ export function sift(stdout: string[]) {
   } catch (error) {
     if (
       error.message.includes("Unexpected end of JSON input") ||
-      error.message.includes("Unterminated string in JSON ")
+      error.message.includes("Unterminated string in JSON ") ||
+      error.message.includes("is not valid JSON ")
     ) {
       console.error("Unexpected JSON input. Offending lines:")
       const offenders = withoutKnownBad


### PR DESCRIPTION
Adding a new failure-handler case to the pepr logs helper to expose full error message for error we're seeing over in Pepr CI:

![image](https://github.com/user-attachments/assets/125fca35-edfa-4a12-8b50-c5b46825928a)

Relates to https://github.com/defenseunicorns/pepr/pull/1676