### PR TITLE
test: suppress ExperimentalWarning: messages in logs helper

### DIFF
--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -11,6 +11,7 @@ export function sift(stdout: string[]) {
   const withoutKnownBad = stdout
     .filter(log => !log.includes('] DeprecationWarning: '))
     .filter(log => !log.includes('--trace-deprecation'))
+    .filter(log => !log.includes('ExperimentalWarning: '))
     .filter(log => log)
 
   try {
@@ -28,7 +29,7 @@ export function sift(stdout: string[]) {
     if (
       error.message.includes("Unexpected end of JSON input") ||
       error.message.includes("Unterminated string in JSON ") ||
-      error.message.includes("is not valid JSON ")
+      error.message.includes("is not valid JSON")
     ) {
       console.error("Unexpected JSON input. Offending lines:")
       const offenders = withoutKnownBad


### PR DESCRIPTION
Helps pepr's e2e test logs helper not choke on warnings like this:

![image](https://github.com/user-attachments/assets/57fea202-32cb-4d02-992a-eb25559320ef)

Relates to https://github.com/defenseunicorns/pepr/pull/1676