### PR TITLE
test: add retries to cluster test data cleanup helper

### DIFF
--- a/_helpers/src/cluster.ts
+++ b/_helpers/src/cluster.ts
@@ -29,8 +29,8 @@ async function retry<T, U>(action: AsyncFunc<T>, reactions: Record<string, Async
   catch (err) {
     let status = err.hasOwnProperty("status") ? `${err.status}` : undefined;
 
-    if (status === '429') {
-      await reactions['429'](err);
+    if (['400', '429'].includes(status)) {
+      await reactions[status](err);
 
       retries -= 1;
       if (retries > 0) {
@@ -70,6 +70,9 @@ export async function up(name: string = 'pexex-helpers-cluster'): Promise<string
   await Promise.all(kinds.map(async (k) => await retry(
     async () => await K8s(k).Get(),
     {
+      '400': async () => {
+        await sleep(5);
+      },
       '404': noop,
       '405': noop,
       '429': async (err: KfcErr) => {

--- a/_helpers/src/cluster.ts
+++ b/_helpers/src/cluster.ts
@@ -100,6 +100,47 @@ export async function clean(trc: TestRunCfg): Promise<void> {
           .length > 0
     )
 
+    // // delete test-labelled resources (in parallel)
+    // tbds.forEach(([k, o]) => K8s(k).Delete(o))
+    // let terminating = tbds.map(tbd => untilTrue(() => gone(...tbd)))
+    // await Promise.all(terminating)
+
+    // PASS  src/cluster.e2e.test.ts (146.086 s)
+    // up()
+    //   ✓ creates a test k3d cluster (47548 ms)
+    // down()
+    //   ✓ deletes a test k3d cluster (45241 ms)
+    // clean()
+    //   ✓ removes resources with TestRunCfg-defined label (2357 ms)
+    //   ✓ removes CRD & CRs with TestRunCfg-defined label (2256 ms)
+
+    // FAIL src/cluster.e2e.test.ts (95.86 s)
+    // up()
+    //   ✓ creates a test k3d cluster (42246 ms)
+    // down()
+    //   ✓ deletes a test k3d cluster (24010 ms)
+    // clean()
+    //   ✕ removes resources with TestRunCfg-defined label (974 ms)
+    //   ✓ removes CRD & CRs with TestRunCfg-defined label (1975 ms)
+
+    // thrown: Object {
+    //   "data": Object {
+    //     "apiVersion": "v1",
+    //     "code": 429,
+    //     "details": Object {
+    //       "retryAfterSeconds": 1,
+    //     },
+    //     "kind": "Status",
+    //     "message": "storage is (re)initializing",
+    //     "metadata": Object {},
+    //     "reason": "TooManyRequests",
+    //     "status": "Failure",
+    //   },
+    //   "ok": false,
+    //   "status": 429,
+    //   "statusText": "Too Many Requests",
+    // }
+
     async function retryDelete(cls: GenericClass, obj: KubernetesObject, retries: number = 3): Promise<void> {
       try {
         return await K8s(cls).Delete(obj);

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
       "dependencies": {
         "dotenv": "^16.4.7",
         "dotenv-cli": "^8.0.0",
-        "pepr": "^0.42.3"
+        "pepr": "^0.42.1"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -478,7 +478,7 @@
       "dependencies": {
         "dotenv": "^16.4.7",
         "dotenv-cli": "^8.0.0",
-        "pepr": "^0.42.3"
+        "pepr": "^0.42.1"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
       "dependencies": {
         "dotenv": "^16.4.7",
         "dotenv-cli": "^8.0.0",
-        "pepr": "^0.42.1"
+        "pepr": "^0.42.3"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -478,7 +478,7 @@
       "dependencies": {
         "dotenv": "^16.4.7",
         "dotenv-cli": "^8.0.0",
-        "pepr": "^0.42.1"
+        "pepr": "^0.42.3"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",


### PR DESCRIPTION
When running the e2es in CI, the cleanup helper's Delete calls are being throttled by the kubeapi server (which is causing the tests to fail) -- this PR adds some error handling surrounding that case & inserts some retry logic in an attempt to course correct.

Relates to https://github.com/defenseunicorns/pepr/issues/1709