### PR TITLE
Test specific version fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10672,7 +10672,7 @@
     "test-specific-version": {
       "version": "0.0.1",
       "dependencies": {
-        "pepr": "0.44.0"
+        "pepr": "^0.44.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/test-specific-version/package.json
+++ b/test-specific-version/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "pepr": "0.44.0"
+    "pepr": "^0.44.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",


### PR DESCRIPTION
PEXEX test-specific-version is failing constantly affecting CI. We need to update the Pepr dependency in order to pass CI and unblock pipelines. 