### PR TITLE
chore: fix package.json in hello-pepr-generic-kind

### DIFF
--- a/hello-pepr-generic-kind/package.json
+++ b/hello-pepr-generic-kind/package.json
@@ -28,9 +28,7 @@
     "env": {}
   },
   "dependencies": {
-    "dotenv": "^16.4.7",
-    "dotenv-cli": "^8.0.0",
-    "pepr": "file:../pepr-0.0.0-development.tgz"
+    "pepr": "^0.45.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,9 +170,7 @@
     "hello-pepr-generic-kind": {
       "version": "0.0.1",
       "dependencies": {
-        "dotenv": "^16.4.7",
-        "dotenv-cli": "^8.0.0",
-        "pepr": "file:../pepr-0.0.0-development.tgz"
+        "pepr": "^0.45.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -183,129 +181,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "hello-pepr-generic-kind/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
-      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "hello-pepr-generic-kind/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.4.0.tgz",
-      "integrity": "sha512-o09cLSIq9EKyRXwryWDOJagkml9XgQCoCSRjHOnHLnvsivaW7Qznzz6yjfV7PHJHhIvyp8OH7OX8w0Dc5bQK7A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "hello-pepr-generic-kind/node_modules/esbuild": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
-      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.0",
-        "@esbuild/android-arm": "0.25.0",
-        "@esbuild/android-arm64": "0.25.0",
-        "@esbuild/android-x64": "0.25.0",
-        "@esbuild/darwin-arm64": "0.25.0",
-        "@esbuild/darwin-x64": "0.25.0",
-        "@esbuild/freebsd-arm64": "0.25.0",
-        "@esbuild/freebsd-x64": "0.25.0",
-        "@esbuild/linux-arm": "0.25.0",
-        "@esbuild/linux-arm64": "0.25.0",
-        "@esbuild/linux-ia32": "0.25.0",
-        "@esbuild/linux-loong64": "0.25.0",
-        "@esbuild/linux-mips64el": "0.25.0",
-        "@esbuild/linux-ppc64": "0.25.0",
-        "@esbuild/linux-riscv64": "0.25.0",
-        "@esbuild/linux-s390x": "0.25.0",
-        "@esbuild/linux-x64": "0.25.0",
-        "@esbuild/netbsd-arm64": "0.25.0",
-        "@esbuild/netbsd-x64": "0.25.0",
-        "@esbuild/openbsd-arm64": "0.25.0",
-        "@esbuild/openbsd-x64": "0.25.0",
-        "@esbuild/sunos-x64": "0.25.0",
-        "@esbuild/win32-arm64": "0.25.0",
-        "@esbuild/win32-ia32": "0.25.0",
-        "@esbuild/win32-x64": "0.25.0"
-      }
-    },
-    "hello-pepr-generic-kind/node_modules/pepr": {
-      "version": "0.0.0-development",
-      "resolved": "file:pepr-0.0.0-development.tgz",
-      "integrity": "sha512-dIzcuQAD3NzHjBpXoWQmdIH+6vR14honMcIBTrLJK8ZyHJTmYcHbkxWBC8zEftbveK1MHOXUJSDBIPy+ZFfEnw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/ramda": "0.30.2",
-        "express": "4.21.2",
-        "fast-json-patch": "3.1.1",
-        "follow-redirects": "1.15.9",
-        "http-status-codes": "^2.3.0",
-        "json-pointer": "^0.6.2",
-        "kubernetes-fluent-client": "3.4.2",
-        "pino": "9.6.0",
-        "pino-pretty": "13.0.0",
-        "prom-client": "15.1.3",
-        "ramda": "0.30.1",
-        "sigstore": "3.1.0"
-      },
-      "bin": {
-        "pepr": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@types/prompts": "2.4.9",
-        "@typescript-eslint/eslint-plugin": "8.23.0",
-        "@typescript-eslint/parser": "8.23.0",
-        "commander": "13.1.0",
-        "esbuild": "0.25.0",
-        "eslint": "8.57.0",
-        "node-forge": "1.3.1",
-        "prettier": "3.4.2",
-        "prompts": "2.4.2",
-        "typescript": "5.7.3",
-        "uuid": "11.0.5"
-      }
-    },
-    "hello-pepr-generic-kind/node_modules/sigstore": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-3.1.0.tgz",
-      "integrity": "sha512-ZpzWAFHIFqyFE56dXqgX/DkDRZdz+rRcjoIk/RQU4IX0wiCv1l8S7ZrXDHcCc+uaf+6o7w3h2l3g6GYG5TKN9Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^3.1.0",
-        "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.4.0",
-        "@sigstore/sign": "^3.1.0",
-        "@sigstore/tuf": "^3.1.0",
-        "@sigstore/verify": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "hello-pepr-hooks": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6046,6 +6046,7 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.4.2.tgz",
       "integrity": "sha512-7T50KkcOae40kX/+oO4ezYp5IUcZQ1GLnirY/z1QLRla6S3Ey6e8uW9lR16+mQdBe6PpoXTcdPkgP7UbdQGtKA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "1.0.0-rc7",
@@ -6068,6 +6069,7 @@
       "version": "4.35.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.35.0.tgz",
       "integrity": "sha512-2/AwEFQDFEy30iOLjrvHDIH7e4HEWH+f1Yl1bI5XMqzuoCUqwYCdxachgsgv0og/JdVZUhbfjcJAoHj5L1753A==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -7510,6 +7512,7 @@
       "version": "23.0.171",
       "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-23.0.171.tgz",
       "integrity": "sha512-2kFUFtVdCbc54IBlCG30Yzsb5a1l6lX/8UjKaf2B009WFsqvduidaSOdJ4IKMhMi7DCrq60mnU7HZ1fDazGRlw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@glideapps/ts-necessities": "2.2.3",
@@ -8642,6 +8645,7 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.3.0.tgz",
       "integrity": "sha512-Qy96NND4Dou5jKoSJ2gm8ax8AJM/Ey9o9mz7KN1bb9GP+G0l20Zw8afxTnY2f4b7hmhn/z8aC2kfArVQlAhFBw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"


### PR DESCRIPTION
For some reason the pepr depedency in `hello-pepr-generic-kind` was using the `npm pack` version of Pepr