### PR TITLE
chore: load-test ts version is incorrect

### DIFF
--- a/hello-pepr-load/package.json
+++ b/hello-pepr-load/package.json
@@ -35,7 +35,7 @@
     "pepr": "^0.45.0"
   },
   "devDependencies": {
-    "typescript": "5.3.3"
+    "typescript": "5.7.3"
   },
   "scripts": {
     "pepr": "pepr",


### PR DESCRIPTION
The load test has not passed in 3 weeks. This is because the dev dependencies were updated on all projects other than the load test. We are not able to install Pepr due to this difference. 

https://github.com/defenseunicorns/pepr/actions/runs/13550823353/job/37873752935#step:15:71

```bash
Install package artifact into working directory module
{
  "cmd": "npm install pepr-0.0.0-development.tgz",
  "cwd": "/tmp/load.cli.ts-M1fyZG"
}
{
  stdout: [],
  stderr: [
    'npm error code ERESOLVE',
    'npm error ERESOLVE unable to resolve dependency tree',
    'npm error',
    'npm error While resolving: hello-pepr-load@0.0.1',
    'npm error Found: typescript@5.3.3',
    'npm error node_modules/typescript',
    'npm error   dev typescript@"5.3.3" from the root project',
    'npm error   peer typescript@">=4.8.4 <5.8.0" from @typescript-eslint/eslint-plugin@8.23.0',
    'npm error   node_modules/@typescript-eslint/eslint-plugin',
    'npm error     peer @typescript-eslint/eslint-plugin@"8.23.0" from pepr@0.0.0-development',
    'npm error     node_modules/pepr',
    'npm error       pepr@"file:pepr-0.0.0-development.tgz" from the root project',
    'npm error   1 more (@typescript-eslint/parser)',
    'npm error',
    'npm error Could not resolve dependency:',
    'npm error peer typescript@"5.7.3" from pepr@0.0.0-development',
    'npm error node_modules/pepr',
    'npm error   pepr@"file:pepr-0.0.0-development.tgz" from the root project',
    'npm error',
    'npm error Fix the upstream dependency conflict, or retry',
    'npm error this command with --force or --legacy-peer-deps',
    'npm error to accept an incorrect (and potentially broken) dependency resolution.',
    'npm error',
    'npm error',
    'npm error For a full report see:',
    'npm error /home/runner/.npm/_logs/2025-02-26T18_30_12_056Z-eresolve-report.txt',
    'npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-02-26T18_30_12_056Z-debug-0.log',
 ```