### PR TITLE
chore: accidental extra when removal

### DIFF
--- a/hello-pepr-generic-kind/capabilities/genericKind.ts
+++ b/hello-pepr-generic-kind/capabilities/genericKind.ts
@@ -9,7 +9,7 @@ export const HelloPeprGenericKind = new Capability({
 });
 
 const { When } = HelloPeprGenericKind;
-When(a.CustomResourceDefinition)
+
 When(a.GenericKind, {
   group: "pepr.dev",
   version: "v1",


### PR DESCRIPTION
Not sure how the extra random `When` got there but it was not the intention. I am surprised this still works but it does. 