### PR TITLE
chore: install custom package at root

### DIFF
--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -84,6 +84,8 @@ const test = program.command('test')
     if (thisCommand.opts().suite === "unit" ){ return }
 
     if (thisCommand.opts().customPackage){
+      // install the custom package at the root
+      execSync(`npm install ${thisCommand.opts().customPackage}`, { cwd: peprExcellentExamplesRepo });
       process.env.PEPR_PACKAGE = `${resolve(peprExcellentExamplesRepo, thisCommand.opts().customPackage)}`
       validateCustomPackage(peprExcellentExamplesRepo);
     }


### PR DESCRIPTION
if you pass a custom package flag, the e2e's were not actually using that version of Pepr, they were using the top level version. With this PR, if you pass in `--custom-package` flag, then it installs it at the root which allows the modules to use it. 