### PR TITLE
chore: test peerDep and workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,87 @@
+name: E2E - Pepr Excellent Examples
+
+permissions: read-all
+on:
+  workflow_dispatch:
+  merge_group:
+    paths-ignore:
+    - "LICENSE"
+    - "CODEOWNERS"
+    - "**.md"
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+
+  examples-matrix:
+    name: job matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.create-matrix.outputs.matrix }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
+      - name: clone pepr-excellent-examples
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: setup node
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: pepr
+
+      - name: create matrix
+        run: |
+          matrix=$(
+            node "$PEPR/.github/workflows/pepr-excellent-examples-matrix.js" "$(pwd)"
+          )
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+        id: create-matrix
+
+  excellent-examples:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    needs:
+      - examples-matrix
+    if: needs.examples-matrix.outputs.matrix != ''
+    strategy:
+      fail-fast: false
+      max-parallel: 32 # Roughly matches the number of E2E tests and below GitHub concurrency limit
+      matrix: ${{ fromJSON(needs.examples-matrix.outputs.matrix) }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          egress-policy: audit
+
+      - name: "install k3d"
+        run: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+        shell: bash
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: setup node
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: install pepr-excellent-examples deps
+        run: |
+          npm ci
+
+      - name: run e2e tests
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          max_attempts: 3
+          retry_on: error
+          timeout_minutes: 6
+          command: |
+            cd "$PEPR_EXCELLENT_EXAMPLES_PATH"
+            npm run --workspace=${{ matrix.name }} test:e2e 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: create matrix
         run: |
           matrix=$(
-            node "$PEPR/.github/workflows/matrix.js" "$(pwd)"
+            node ".github/workflows/matrix.js" "$(pwd)"
           )
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
         id: create-matrix

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: create matrix
         run: |
           matrix=$(
-            node "$PEPR/.github/workflows/pepr-excellent-examples-matrix.js" "$(pwd)"
+            node "$PEPR/.github/workflows/matrix.js" "$(pwd)"
           )
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
         id: create-matrix
@@ -68,7 +68,7 @@ jobs:
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 22
-          
+
       - name: install pepr-excellent-examples deps
         run: |
           npm ci

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,12 +29,10 @@ jobs:
       - name: clone pepr-excellent-examples
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: setup node
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+      - name: Use Node.js 22
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: 20
-          cache: "npm"
-          cache-dependency-path: pepr
+          node-version: 22
 
       - name: create matrix
         run: |
@@ -66,12 +64,11 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: setup node
-        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+      - name: Use Node.js 22
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 22
-          cache: "npm"
-
+          
       - name: install pepr-excellent-examples deps
         run: |
           npm ci
@@ -83,5 +80,4 @@ jobs:
           retry_on: error
           timeout_minutes: 6
           command: |
-            cd "$PEPR_EXCELLENT_EXAMPLES_PATH"
             npm run --workspace=${{ matrix.name }} test:e2e 

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -15,20 +15,16 @@ let examples = stdout.toLocaleString().trim().split("\n");
 
 // select those with 'test:e2e' scripts
 let e2es = examples
-  .map((ex) => [ex, require(`${ex}/package.json`)])
-  .filter(([ex, cfg]) => Object.hasOwn(cfg.scripts, "test:e2e"));
+  .map(ex => [ex, require(`${ex}/package.json`)])
+  .filter(([ex, cfg]) => Object.hasOwn(cfg.scripts, "test:e2e"))
+  .filter(([ex, cfg]) => cfg.name !== "test-specific-version") // requires package.json.bak which is only present when overriding the Pepr version
 
 // gen matrix spec
 let spec = {
-  include: e2es.map(([ex, cfg]) => {
-    // requires package.json.bak which is only present when overriding the version
-    if (cfg.name !== "test-specific-version") {
-      return {
-        name: cfg.name,
-        path: ex,
-      };
-    }
-  }),
+  include: e2es.map(([ex, cfg]) => ({
+    name: cfg.name,
+    path: ex,
+  })),
 };
-
+  
 console.log(JSON.stringify(spec));

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -1,0 +1,29 @@
+// ----- deps ----- //
+const { execSync } = require("node:child_process");
+
+// ----- args ----- //
+process.argv.shift(); // node
+process.argv.shift(); // script
+const peprExcellentExamplesPath = process.argv.shift(); // abs path to pepr-excellent-examples
+
+// ----- main ----- //
+
+// find examples
+let cmd = "npm exec -c pwd -ws";
+let stdout = execSync(cmd, { cwd: peprExcellentExamplesPath });
+let examples = stdout.toLocaleString().trim().split("\n");
+
+// select those with 'test:e2e' scripts
+let e2es = examples
+  .map(ex => [ex, require(`${ex}/package.json`)])
+  .filter(([ex, cfg]) => Object.hasOwn(cfg.scripts, "test:e2e"));
+
+// gen matrix spec
+let spec = {
+  include: e2es.map(([ex, cfg]) => ({
+    name: cfg.name,
+    path: ex,
+  })),
+};
+
+console.log(JSON.stringify(spec));

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -15,15 +15,20 @@ let examples = stdout.toLocaleString().trim().split("\n");
 
 // select those with 'test:e2e' scripts
 let e2es = examples
-  .map(ex => [ex, require(`${ex}/package.json`)])
+  .map((ex) => [ex, require(`${ex}/package.json`)])
   .filter(([ex, cfg]) => Object.hasOwn(cfg.scripts, "test:e2e"));
 
 // gen matrix spec
 let spec = {
-  include: e2es.map(([ex, cfg]) => ({
-    name: cfg.name,
-    path: ex,
-  })),
+  include: e2es.map(([ex, cfg]) => {
+    // requires package.json.bak which is only present when overriding the version
+    if (cfg.name !== "test-specific-version") {
+      return {
+        name: cfg.name,
+        path: ex,
+      };
+    }
+  }),
 };
 
 console.log(JSON.stringify(spec));

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -68,7 +68,7 @@ const test = program.command('test')
       "test a specified pepr cli .tgz package",
     ).conflicts('localPackage')
   )
-  .requiredOption(
+  .option(
       "-i, --image <image>",
       "pepr controller image under test"
   )

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -91,7 +91,9 @@ const test = program.command('test')
     else if (thisCommand.opts().localPackage){
       process.env.PEPR_PACKAGE = buildLocalPepr(peprExcellentExamplesRepo)
     }
-    process.env.PEPR_IMAGE = thisCommand.opts().image
+    else if (thisCommand.opts().image){
+      process.env.PEPR_IMAGE = thisCommand.opts().image
+    }
 
     try {
       backupPackageJSON();

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -70,8 +70,7 @@ const test = program.command('test')
   )
   .requiredOption(
       "-i, --image <image>",
-      "pepr controller image under test",
-      "pepr:dev"
+      "pepr controller image under test"
   )
   .addOption(
     new Option(
@@ -137,7 +136,9 @@ function printTestInfo() {
       const peprVersion = execSync(`npx --yes ${getPeprAlias()} --version`).toString();
       console.log(`Pepr Version under test: ${peprVersion}`);
     }
-    console.log(`Pepr Image under test: ${execSync(`docker inspect --format="{{.Id}} {{.RepoTags}}" ${process.env.PEPR_IMAGE}`).toString()}`);
+    if (process.env.PEPR_IMAGE) {
+      console.log(`Pepr Image under test: ${execSync(`docker inspect --format="{{.Id}} {{.RepoTags}}" ${process.env.PEPR_IMAGE}`).toString()}`);
+    }
 }
 
 function buildLocalPepr(outputDirectory: string) {

--- a/_helpers/package.json
+++ b/_helpers/package.json
@@ -13,7 +13,7 @@
     "commander": "^13.1.0",
     "find-up": "^7.0.0",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "ts-jest": "^29.3.2",
     "ts-node": "^10.9.2",
     "typescript": "5.7.3",

--- a/hello-pepr-alias/package.json
+++ b/hello-pepr-alias/package.json
@@ -36,7 +36,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-config-ignored-ns/package.json
+++ b/hello-pepr-config-ignored-ns/package.json
@@ -32,7 +32,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-config/package.json
+++ b/hello-pepr-config/package.json
@@ -39,7 +39,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-custom-rbac/package.json
+++ b/hello-pepr-custom-rbac/package.json
@@ -30,7 +30,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-deletion-timestamp/package.json
+++ b/hello-pepr-deletion-timestamp/package.json
@@ -36,7 +36,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-finalize/package.json
+++ b/hello-pepr-finalize/package.json
@@ -36,7 +36,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-generic-kind/package.json
+++ b/hello-pepr-generic-kind/package.json
@@ -34,7 +34,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-hooks/package.json
+++ b/hello-pepr-hooks/package.json
@@ -30,7 +30,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-mutate/package.json
+++ b/hello-pepr-mutate/package.json
@@ -29,7 +29,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-ns-all/package.json
+++ b/hello-pepr-ns-all/package.json
@@ -28,7 +28,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-ns-bounded/package.json
+++ b/hello-pepr-ns-bounded/package.json
@@ -30,7 +30,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-ns-wrong/package.json
+++ b/hello-pepr-ns-wrong/package.json
@@ -28,7 +28,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-onschedule/package.json
+++ b/hello-pepr-onschedule/package.json
@@ -34,7 +34,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-reconcile-global/package.json
+++ b/hello-pepr-reconcile-global/package.json
@@ -36,7 +36,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-reconcile-kind/package.json
+++ b/hello-pepr-reconcile-kind/package.json
@@ -36,7 +36,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-reconcile-kindns/package.json
+++ b/hello-pepr-reconcile-kindns/package.json
@@ -36,7 +36,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-reconcile-kindnsname/package.json
+++ b/hello-pepr-reconcile-kindnsname/package.json
@@ -36,7 +36,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-regex-name/package.json
+++ b/hello-pepr-regex-name/package.json
@@ -32,7 +32,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-regex-ns-all/package.json
+++ b/hello-pepr-regex-ns-all/package.json
@@ -28,7 +28,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-regex-ns-bounded/package.json
+++ b/hello-pepr-regex-ns-bounded/package.json
@@ -30,7 +30,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-regex-ns-wrong/package.json
+++ b/hello-pepr-regex-ns-wrong/package.json
@@ -28,7 +28,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-store-redact-logs/package.json
+++ b/hello-pepr-store-redact-logs/package.json
@@ -33,7 +33,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-store/package.json
+++ b/hello-pepr-store/package.json
@@ -32,7 +32,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-validate/package.json
+++ b/hello-pepr-validate/package.json
@@ -29,7 +29,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/hello-pepr-watch/package.json
+++ b/hello-pepr-watch/package.json
@@ -36,7 +36,7 @@
     "@jest/globals": "^29.7.0",
     "@types/node": "^22.14.1",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,10 @@
         "hello-pepr-watch",
         "pepr-operator",
         "test-specific-version"
-      ]
+      ],
+      "dependencies": {
+        "kubernetes-fluent-client": "^3.4.10"
+      }
     },
     "_helpers": {
       "name": "helpers",
@@ -53,7 +56,6 @@
         "commander": "^13.1.0",
         "find-up": "^7.0.0",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "ts-jest": "^29.3.2",
         "ts-node": "^10.9.2",
         "typescript": "5.7.3",
@@ -81,7 +83,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -97,7 +98,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -113,7 +113,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -129,7 +128,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -145,7 +143,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -161,7 +158,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -177,7 +173,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -193,7 +188,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -209,7 +203,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -225,7 +218,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -241,7 +233,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -257,7 +248,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -273,7 +263,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -289,7 +278,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -305,7 +293,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -321,7 +308,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -337,7 +323,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -353,7 +338,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -369,7 +353,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -385,7 +368,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -401,7 +383,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -429,7 +410,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -445,7 +425,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -461,7 +440,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -496,7 +474,6 @@
         "@jest/globals": "^29.7.0",
         "@types/node": "^22.14.1",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -6455,9 +6432,9 @@
       }
     },
     "node_modules/kubernetes-fluent-client/node_modules/type-fest": {
-      "version": "4.39.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.1.tgz",
-      "integrity": "sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
+      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -7366,49 +7343,6 @@
         "prompts": "2.4.2",
         "typescript": "5.7.3",
         "uuid": "11.0.5"
-      }
-    },
-    "node_modules/pepr/node_modules/kubernetes-fluent-client": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/kubernetes-fluent-client/-/kubernetes-fluent-client-3.4.6.tgz",
-      "integrity": "sha512-n3U86mt9hFv0C7UrbGoUvZqfhmg/pCkPZesPZE6+ar64zs/wEFFD0AAJjKtzwWkCRZuI9XYKvXrNRqY1iAg4lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@kubernetes/client-node": "1.0.0-rc7",
-        "fast-json-patch": "3.1.1",
-        "http-status-codes": "2.3.0",
-        "node-fetch": "2.7.0",
-        "quicktype-core": "23.0.171",
-        "type-fest": "4.38.0",
-        "undici": "7.6.0",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "kubernetes-fluent-client": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/pepr/node_modules/type-fest": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.38.0.tgz",
-      "integrity": "sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pepr/node_modules/undici": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.6.0.tgz",
-      "integrity": "sha512-gaFsbThjrDGvAaD670r81RZro/s6H2PVZF640Qn0p5kZK+/rim7/mmyfp2W7VB5vOMaFM8vuFBJUaMlaZTYHlA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/picocolors": {
@@ -9419,7 +9353,6 @@
         "@types/node": "^22.14.1",
         "find-up": "^7.0.0",
         "jest": "^29.7.0",
-        "kubernetes-fluent-client": "^3.4.10",
         "typescript": "5.7.3"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "hello-pepr-watch",
     "pepr-operator",
     "test-specific-version"
-  ]
+  ],
+  "dependencies": {
+    "kubernetes-fluent-client": "^3.4.10"
+  }
 }

--- a/test-specific-version/package.json
+++ b/test-specific-version/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^22.14.1",
     "find-up": "^7.0.0",
     "jest": "^29.7.0",
-    "kubernetes-fluent-client": "^3.4.10",
+
     "typescript": "5.7.3"
   },
   "scripts": {


### PR DESCRIPTION
Adds the ability to use an arbitrary version of KFC by listing it as a `peerDependency` and installing as a dependency in the top level `package.json`. This adds tests to ensure that everything still works.

There was a docker inspect command that was trying to inspect `pepr:dev` which was the default value for image. Docker has not loaded in any image at that point so the command would have failed unless you had loaded pepr:dev into the container. This test is a generic test to ensure that the local changes had not affected the e2e tests, so the goal is to test based on the version in the package.json, which is pulled from GHCR upon deployment of the module. 

Pepr explicitly passes in the pepr:dev image while executing e2e tests https://github.com/defenseunicorns/pepr/blob/main/.github/workflows/pepr-excellent-examples.yml#L202

Closes https://github.com/defenseunicorns/pepr-excellent-examples/issues/231
Closes https://github.com/defenseunicorns/pepr-excellent-examples/issues/266