### PR TITLE
chore: store webapp specs as yaml files

### DIFF
--- a/pepr-operator/webapp-dark-es.yaml
+++ b/pepr-operator/webapp-dark-es.yaml
@@ -1,0 +1,9 @@
+kind: WebApp
+apiVersion: pepr.io/v1alpha1
+metadata:
+  name: webapp-light-en
+  namespace: webapps
+spec:
+  theme: dark 
+  language: es
+  replicas: 1 

--- a/pepr-operator/webapp-light-en.yaml
+++ b/pepr-operator/webapp-light-en.yaml
@@ -1,0 +1,9 @@
+kind: WebApp
+apiVersion: pepr.io/v1alpha1
+metadata:
+  name: webapp-light-en
+  namespace: webapps
+spec:
+  theme: light 
+  language: en
+  replicas: 1 


### PR DESCRIPTION
This PR stores webapp specs as yaml files for easy modification in the future and to support `diff` in the operator tutorial.