### PR TITLE
chore: increase moduleUp timelimit

### DIFF
--- a/hello-pepr-alias/capabilities/alias.e2e.test.ts
+++ b/hello-pepr-alias/capabilities/alias.e2e.test.ts
@@ -9,7 +9,7 @@ import { K8s, kind } from "pepr";
 const trc = new TestRunCfg(__filename);
 
 describe("alias.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
   afterAll(async () => {
     await clean(trc);
     await moduleDown();

--- a/hello-pepr-config-ignored-controller-ns/capabilities/ignored-ns.e2e.test.ts
+++ b/hello-pepr-config-ignored-controller-ns/capabilities/ignored-ns.e2e.test.ts
@@ -14,7 +14,7 @@ const apply = async res => {
 const trc = new TestRunCfg(__filename);
 
 describe("ignored-controller-ns.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
 
   afterAll(async () => await moduleDown(), mins(2));
 

--- a/hello-pepr-config-ignored-ns/capabilities/ignored-ns.e2e.test.ts
+++ b/hello-pepr-config-ignored-ns/capabilities/ignored-ns.e2e.test.ts
@@ -14,7 +14,7 @@ const apply = async res => {
 const trc = new TestRunCfg(__filename);
 
 describe("ignored-ns.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
 
   afterAll(async () => await moduleDown(), mins(2));
 

--- a/hello-pepr-config/capabilities/config.e2e.test.ts
+++ b/hello-pepr-config/capabilities/config.e2e.test.ts
@@ -24,7 +24,7 @@ const apply = async res => {
 const trc = new TestRunCfg(__filename)
 
 describe("config.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2))
+  beforeAll(async () => await moduleUp(), mins(4))
 
   afterAll(async () => await moduleDown(), mins(2))
 

--- a/hello-pepr-deletion-timestamp/capabilities/deletion.e2e.test.ts
+++ b/hello-pepr-deletion-timestamp/capabilities/deletion.e2e.test.ts
@@ -9,7 +9,7 @@ import { K8s, kind } from "pepr";
 const trc = new TestRunCfg(__filename);
 
 describe("deletion.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
   afterAll(async () => {
     await moduleDown()
     await clean(trc)

--- a/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
+++ b/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
@@ -10,7 +10,7 @@ import { KubernetesObject } from "kubernetes-fluent-client";
 const trc = new TestRunCfg(__filename);
 
 describe("finalize.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
   afterAll(async () => {
     await clean(trc)
     await moduleDown()

--- a/hello-pepr-generic-kind/capabilities/genericKind.e2e.test.ts
+++ b/hello-pepr-generic-kind/capabilities/genericKind.e2e.test.ts
@@ -19,7 +19,7 @@ describe("genericKind.ts", () => {
     const resources = await trc.load(file);
     await fullCreate(resources, kind);
     await moduleUp()
-  }, mins(2));
+  }, mins(4));
 
   afterAll(async () => {
     await moduleDown();

--- a/hello-pepr-hooks/capabilities/hooks.e2e.test.ts
+++ b/hello-pepr-hooks/capabilities/hooks.e2e.test.ts
@@ -20,7 +20,7 @@ const apply = async res => {
 const trc = new TestRunCfg(__filename)
 
 describe("hooks.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2))
+  beforeAll(async () => await moduleUp(), mins(4))
 
   afterAll(async () => await moduleDown(), mins(2))
 

--- a/hello-pepr-mutate/capabilities/mutate.e2e.test.ts
+++ b/hello-pepr-mutate/capabilities/mutate.e2e.test.ts
@@ -18,7 +18,7 @@ import cfg from "../package.json";
 const trc = new TestRunCfg(__filename)
 
 describe("mutate.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2))
+  beforeAll(async () => await moduleUp(), mins(4))
   afterAll(async () => {
     await clean(trc)
     await moduleDown()

--- a/hello-pepr-ns-all/capabilities/namespace.e2e.test.ts
+++ b/hello-pepr-ns-all/capabilities/namespace.e2e.test.ts
@@ -20,7 +20,7 @@ const apply = async res => {
 const trc = new TestRunCfg(__filename)
 
 describe("namespace.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2))
+  beforeAll(async () => await moduleUp(), mins(4))
 
   afterAll(async () => await moduleDown(), mins(2))
 

--- a/hello-pepr-ns-bounded/capabilities/namespace.e2e.test.ts
+++ b/hello-pepr-ns-bounded/capabilities/namespace.e2e.test.ts
@@ -20,7 +20,7 @@ const apply = async res => {
 const trc = new TestRunCfg(__filename)
 
 describe("namespace.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2))
+  beforeAll(async () => await moduleUp(), mins(4))
 
   afterAll(async () => await moduleDown(), mins(2))
 

--- a/hello-pepr-onschedule/capabilities/onschedule.e2e.test.ts
+++ b/hello-pepr-onschedule/capabilities/onschedule.e2e.test.ts
@@ -16,7 +16,7 @@ const delta = (one, two, firstRunDelay = secs(10)) => {
 }
 
 describe("schedule.ts", () => {
-  beforeAll(async () => { await moduleUp() }, mins(3))
+  beforeAll(async () => { await moduleUp() }, mins(4))
   afterAll(async () => { await moduleDown() }, mins(2))
 
   it("runs forever", async () => {

--- a/hello-pepr-reconcile-global/capabilities/reconcile.e2e.test.ts
+++ b/hello-pepr-reconcile-global/capabilities/reconcile.e2e.test.ts
@@ -9,7 +9,7 @@ import { K8s, kind } from "pepr";
 const trc = new TestRunCfg(__filename);
 
 describe("reconcile.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
   afterAll(async () => {
     await moduleDown()
     await clean(trc)

--- a/hello-pepr-reconcile-kind/capabilities/reconcile.e2e.test.ts
+++ b/hello-pepr-reconcile-kind/capabilities/reconcile.e2e.test.ts
@@ -9,7 +9,7 @@ import { K8s, kind } from "pepr";
 const trc = new TestRunCfg(__filename);
 
 describe("reconcile.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
   afterAll(async () => {
     await moduleDown()
     await clean(trc)

--- a/hello-pepr-reconcile-kindns/capabilities/reconcile.e2e.test.ts
+++ b/hello-pepr-reconcile-kindns/capabilities/reconcile.e2e.test.ts
@@ -9,7 +9,7 @@ import { K8s, kind } from "pepr";
 const trc = new TestRunCfg(__filename);
 
 describe("reconcile.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
   afterAll(async () => {
     await moduleDown()
     await clean(trc)

--- a/hello-pepr-reconcile-kindnsname/capabilities/reconcile.e2e.test.ts
+++ b/hello-pepr-reconcile-kindnsname/capabilities/reconcile.e2e.test.ts
@@ -9,7 +9,7 @@ import { K8s, kind } from "pepr";
 const trc = new TestRunCfg(__filename);
 
 describe("reconcile.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
   afterAll(async () => {
     await moduleDown()
     await clean(trc)

--- a/hello-pepr-regex-name/capabilities/regex-name.e2e.test.ts
+++ b/hello-pepr-regex-name/capabilities/regex-name.e2e.test.ts
@@ -14,7 +14,7 @@ const apply = async res => {
 const trc = new TestRunCfg(__filename);
 
 describe("regex-name.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
 
   afterAll(async () => await moduleDown(), mins(2));
 

--- a/hello-pepr-regex-ns-all/capabilities/namespace.e2e.test.ts
+++ b/hello-pepr-regex-ns-all/capabilities/namespace.e2e.test.ts
@@ -20,7 +20,7 @@ const apply = async res => {
 const trc = new TestRunCfg(__filename)
 
 describe("namespace.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2))
+  beforeAll(async () => await moduleUp(), mins(4))
 
   afterAll(async () => await moduleDown(), mins(2))
 

--- a/hello-pepr-regex-ns-bounded/capabilities/namespace.e2e.test.ts
+++ b/hello-pepr-regex-ns-bounded/capabilities/namespace.e2e.test.ts
@@ -20,7 +20,7 @@ const apply = async res => {
 const trc = new TestRunCfg(__filename)
 
 describe("namespace.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2))
+  beforeAll(async () => await moduleUp(), mins(4))
 
   afterAll(async () => await moduleDown(), mins(2))
 

--- a/hello-pepr-store-redact-logs/capabilities/store.e2e.test.ts
+++ b/hello-pepr-store-redact-logs/capabilities/store.e2e.test.ts
@@ -13,7 +13,7 @@ const apply = async res => {
 const trc = new TestRunCfg(__filename);
 
 describe("store.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
 
   afterAll(async () => {
     await moduleDown();

--- a/hello-pepr-store-resources/capabilities/store.e2e.test.ts
+++ b/hello-pepr-store-resources/capabilities/store.e2e.test.ts
@@ -29,7 +29,7 @@ describe("store.ts", () => {
       `kubectl apply -f ${trc.root()}/capabilities/nonmigrated-peprstore.yaml`,
       { stdio: "inherit" },
     );
-    await moduleUp(), mins(2);
+    await moduleUp(), mins(4);
   }, secs(90));
 
   describe("Store Resource", () => {

--- a/hello-pepr-store/capabilities/store.e2e.test.ts
+++ b/hello-pepr-store/capabilities/store.e2e.test.ts
@@ -13,7 +13,7 @@ const apply = async res => {
 const trc = new TestRunCfg(__filename);
 
 describe("store.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
 
   afterAll(async () => {
     await moduleDown();

--- a/hello-pepr-validate/capabilities/validate.e2e.test.ts
+++ b/hello-pepr-validate/capabilities/validate.e2e.test.ts
@@ -16,7 +16,7 @@ import { K8s, kind } from 'pepr';
 const trc = new TestRunCfg(__filename)
 
 describe("validate.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2))
+  beforeAll(async () => await moduleUp(), mins(4))
   afterAll(async () => {
     await moduleDown()
     await clean(trc)

--- a/hello-pepr-warnings/capabilities/warnings.e2e.test.ts
+++ b/hello-pepr-warnings/capabilities/warnings.e2e.test.ts
@@ -15,7 +15,7 @@ import { mins, secs } from 'helpers/src/time';
 const trc = new TestRunCfg(__filename);
 
 describe("warnings.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
   afterAll(async () => {
     await moduleDown();
     await clean(trc);

--- a/hello-pepr-watch/capabilities/watch.e2e.test.ts
+++ b/hello-pepr-watch/capabilities/watch.e2e.test.ts
@@ -9,7 +9,7 @@ import { moduleUp, moduleDown, untilLogged } from "helpers/src/pepr";
 const trc = new TestRunCfg(__filename);
 
 describe("watch.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(2));
+  beforeAll(async () => await moduleUp(), mins(4));
   afterAll(async () => {
     await moduleDown();
     await clean(trc);


### PR DESCRIPTION
We have been hitting timeouts in the runners. It seems more frequently right now that the whole module is not coming up as the webhook is not reachable by Kubernetes. If we increase the initial limit around actually deploying the webhook those pods are more likely to be up and healthy and the theory is we will get less flakes. 