### PR TITLE
fix: update version in missed test case

### DIFF
--- a/test-specific-version/package.json
+++ b/test-specific-version/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "pepr": "0.49.0"
+    "pepr": "0.50.0-nightly.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",


### PR DESCRIPTION
This PR fixes a missed version bump following the ESlint migration in #294 