### PR TITLE
chore: update pepr installation and check

### DIFF
--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -172,11 +172,11 @@ function restorePackageJSON() {
 }
 
 function backupPackageJSON() {
-  if (basename(process.cwd()) !== '_helpers' && getPeprAlias() !== 'pepr' || process.env.KFC_PACKAGE === "kubernetes-fluent-client-0.0.0-development.tgz") {
+  if (basename(process.cwd()) !== '_helpers' && !getPeprAlias().startsWith('pepr') || process.env.KFC_PACKAGE === "kubernetes-fluent-client-0.0.0-development.tgz") {
     copyFileSync(`${peprExcellentExamplesRepo}/package-lock.json`, `${peprExcellentExamplesRepo}/package-lock.json.bak`);
     copyFileSync(`${peprExcellentExamplesRepo}/package.json`, `${peprExcellentExamplesRepo}/package.json.bak`);
     copyFileSync(`${process.cwd()}/package.json`, `${process.cwd()}/package.json.bak`);
-    execSync(`npm i ${getPeprAlias()}`);
+    execSync(`npm i ${getPeprAlias()} --force`);
     rmSync(`${peprExcellentExamplesRepo}/package-lock.json`);
   }
 }


### PR DESCRIPTION
fixes #312 

Since switching to ESLint v9.x we had to update dependencies in Pepr. We also had to change logic in PEXEX to install the nightly version of pepr as seen in this [PR](https://github.com/defenseunicorns/pepr-excellent-examples/pull/307/files). Before we were installing npm i pepr, and seeing check if the pepr env is pepr. Now we are installing pepr@nightly which makes this check never return positive getPeprAlias() !== 'pepr'. We need to change that to .StartsWith("pepr")` so we can return true for a nightly and also we need to force install the dependencies since there are some clashes due to newer versions of dependencies in the nightly.