### PR TITLE
chore: install after backup

### DIFF
--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -102,8 +102,8 @@ const test = program.command('test')
 
     try {
       process.env.KFC_PACKAGE = thisCommand.opts().kfc
-      execSync('npm install', { cwd: peprExcellentExamplesRepo });
       backupPackageJSON();
+      execSync('npm install', { cwd: peprExcellentExamplesRepo });
     } catch (err) {
       throw new Error(`Failed to run npm install in ${peprExcellentExamplesRepo}. Check package.json and package-lock.json. Error: ${err.message}`);
     }

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -119,7 +119,9 @@ const test = program.command('test')
       }
     }
     finally{
-      restorePackageJSON();
+      if(process.env.CI === 'true') {
+        restorePackageJSON();
+      }
     }
   })
 

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -103,9 +103,6 @@ const test = program.command('test')
     try {
       process.env.KFC_PACKAGE = thisCommand.opts().kfc
       backupPackageJSON();
-      if( thisCommand.opts().kfc){
-        execSync(`npm install ${thisCommand.opts().kfc}`, { cwd: peprExcellentExamplesRepo });
-      }
     } catch (err) {
       throw new Error(`Failed to run npm install in ${peprExcellentExamplesRepo}. Check package.json and package-lock.json. Error: ${err.message}`);
     }

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -103,7 +103,6 @@ const test = program.command('test')
     try {
       process.env.KFC_PACKAGE = thisCommand.opts().kfc
       backupPackageJSON();
-      execSync('npm install', { cwd: peprExcellentExamplesRepo });
       if( thisCommand.opts().kfc){
         execSync(`npm install ${thisCommand.opts().kfc}`, { cwd: peprExcellentExamplesRepo });
       }
@@ -177,6 +176,9 @@ function backupPackageJSON() {
     copyFileSync(`${peprExcellentExamplesRepo}/package.json`, `${peprExcellentExamplesRepo}/package.json.bak`);
     copyFileSync(`${process.cwd()}/package.json`, `${process.cwd()}/package.json.bak`);
     execSync(`npm i ${getPeprAlias()}`);
+    if(process.env.KFC_PACKAGE === "kubernetes-fluent-client-0.0.0-development.tgz") {
+      execSync('npm install', { cwd: peprExcellentExamplesRepo });
+    }
     rmSync(`${peprExcellentExamplesRepo}/package-lock.json`);
   }
 }

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -102,6 +102,7 @@ const test = program.command('test')
 
     try {
       process.env.KFC_PACKAGE = thisCommand.opts().kfc
+      execSync('npm install', { cwd: peprExcellentExamplesRepo });
       backupPackageJSON();
     } catch (err) {
       throw new Error(`Failed to run npm install in ${peprExcellentExamplesRepo}. Check package.json and package-lock.json. Error: ${err.message}`);

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -177,7 +177,7 @@ function backupPackageJSON() {
     copyFileSync(`${process.cwd()}/package.json`, `${process.cwd()}/package.json.bak`);
     execSync(`npm i ${getPeprAlias()}`);
     if(process.env.KFC_PACKAGE === "kubernetes-fluent-client-0.0.0-development.tgz") {
-      execSync('npm install', { cwd: peprExcellentExamplesRepo });
+      execSync(`npm install ${process.env.KFC_PACKAGE}`, { cwd: peprExcellentExamplesRepo });
     }
     rmSync(`${peprExcellentExamplesRepo}/package-lock.json`);
   }

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -120,7 +120,7 @@ const test = program.command('test')
       }
     }
     finally{
-      if(process.env.CI === 'true') {
+      if(process.env.CI !== 'true') {
         restorePackageJSON();
       }
     }


### PR DESCRIPTION
https://github.com/defenseunicorns/kubernetes-fluent-client/issues/675

KFC cannot install updates, it is choking on the `restoreBackup()`. During the backup restore this now restores the original package*.json


This also uses the standard CI env var for github actions CI
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables