### PR TITLE
chore: ignore dependabot updates for jest v30

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
         dependency-type: "production"
       dev:
         dependency-type: "development"
+    ignore:
+      - dependency-name: "jest"
+        versions: ["30"]
+      - dependency-name: "@jest/globals"
+        versions: ["30"]
 
     allow:
       - dependency-type: "production"


### PR DESCRIPTION
This PR ignores dependabot updates that introduce breaking changes.