### PR TITLE
chore: module up should look for module deployed successfully

### DIFF
--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -141,7 +141,7 @@ export async function moduleUp({ version = "", verbose = false, rbacMode = "admi
   if (verbose) { console.log(deploy) }
   console.timeEnd(cmd)
 
-  await untilLogged('✅ Scheduling processed', 2)
+  await untilLogged('✅ Module deployed successfully', 1)
   console.timeEnd(`pepr@${version} ready (total time)`)
 }
 


### PR DESCRIPTION
PR #[2359](https://github.com/defenseunicorns/pepr/pull/2359) in Pepr updated the build and deploy to only deploy necessary resources for the current module. 

This means if you module does not use watch, then the watch manifests will not be _deployed_ or _build_, and likewise with `Mutate()` and `Validate()`.

The problem with moduleUp is that it is assuming the module is ready when `Scheduling processes` is logged twice, however this is inaccurate as this log will not exist unless there is an actual schedule. `npx pepr deploy` actually logs `Module deployed successfully` just one time. 