### PR TITLE
chore: e2e tests for 2359

### DIFF
--- a/hello-pepr-config/capabilities/config.e2e.test.ts
+++ b/hello-pepr-config/capabilities/config.e2e.test.ts
@@ -1,91 +1,130 @@
-import {
-  beforeAll,
-  afterAll,
-  describe,
-  it,
-  expect,
-} from "@jest/globals";
+import { beforeAll, afterAll, describe, it, expect } from "@jest/globals";
 import { K8s, kind } from "kubernetes-fluent-client";
 import { TestRunCfg } from "helpers/src/TestRunCfg";
 import { halfCreate, fullCreate } from "helpers/src/general";
-import { secs, mins, sleep, timed } from 'helpers/src/time';
-import { moduleUp, moduleDown, untilLogged, logs } from 'helpers/src/pepr';
-import { clean } from 'helpers/src/cluster';
+import { secs, mins, sleep, timed } from "helpers/src/time";
+import { moduleUp, moduleDown, untilLogged, logs } from "helpers/src/pepr";
+import { clean } from "helpers/src/cluster";
 import cfg from "../package.json";
-
 
 // kind["ClusterPolicyReport"] = ClusterPolicyReport
 // kind["Exemption"] = Exemption
 
 const apply = async res => {
   return await fullCreate(res, kind);
-}
+};
 
-const trc = new TestRunCfg(__filename)
+const trc = new TestRunCfg(__filename);
 
 describe("config.ts", () => {
-  beforeAll(async () => await moduleUp(), mins(4))
+  beforeAll(async () => await moduleUp(), mins(4));
 
-  afterAll(async () => await moduleDown(), mins(2))
+  afterAll(async () => await moduleDown(), mins(2));
 
   describe("respects package.json > pepr key:", () => {
-
     beforeAll(async () => {
-      const file = `${trc.root()}/capabilities/scenario.config.yaml`
+      const file = `${trc.root()}/capabilities/scenario.config.yaml`;
       await timed(`load: ${file}`, async () => {
-        const resources = await trc.load(file)
-        const resources_applied = await apply(resources)
-  
-        await untilLogged('"msg":"noop"')
-      })
-    })
+        const resources = await trc.load(file);
+        const resources_applied = await apply(resources);
 
-    afterAll(async () => await clean(trc), mins(5))
+        await untilLogged('"msg":"noop"');
+      });
+    });
 
-    const moduleName = `pepr-${cfg.pepr.uuid}`
+    afterAll(async () => await clean(trc), mins(5));
 
-    it("webhookTimeout", async () => {
-      const mwc = await K8s(kind.MutatingWebhookConfiguration).Get(moduleName)
-      const vwc = await K8s(kind.ValidatingWebhookConfiguration).Get(moduleName)
+    const moduleName = `pepr-${cfg.pepr.uuid}`;
 
-      expect(mwc.webhooks![0].timeoutSeconds).toBe(cfg.pepr.webhookTimeout)
-      expect(vwc.webhooks![0].timeoutSeconds).toBe(cfg.pepr.webhookTimeout)
-    }, secs(10))
+    it(
+      "webhookTimeout",
+      async () => {
+        const mwc = await K8s(kind.MutatingWebhookConfiguration).Get(
+          moduleName,
+        );
+        const vwc = await K8s(kind.ValidatingWebhookConfiguration).Get(
+          moduleName,
+        );
 
-    it("onError", async () => {
-      const mwc = await K8s(kind.MutatingWebhookConfiguration).Get(moduleName)
-      const vwc = await K8s(kind.ValidatingWebhookConfiguration).Get(moduleName)
+        expect(mwc.webhooks![0].timeoutSeconds).toBe(cfg.pepr.webhookTimeout);
+        expect(vwc.webhooks![0].timeoutSeconds).toBe(cfg.pepr.webhookTimeout);
+      },
+      secs(10),
+    );
 
-      const failurePolicy =
-        cfg.pepr.onError == "reject" ? "Fail" :
-        cfg.pepr.onError == "ignore" ? "Ignore" : null
+    it(
+      "onError",
+      async () => {
+        const mwc = await K8s(kind.MutatingWebhookConfiguration).Get(
+          moduleName,
+        );
+        const vwc = await K8s(kind.ValidatingWebhookConfiguration).Get(
+          moduleName,
+        );
 
-      expect(mwc.webhooks![0].failurePolicy).toBe(failurePolicy)
-      expect(vwc.webhooks![0].failurePolicy).toBe(failurePolicy)
-    }, secs(10))
+        const failurePolicy =
+          cfg.pepr.onError == "reject"
+            ? "Fail"
+            : cfg.pepr.onError == "ignore"
+              ? "Ignore"
+              : null;
 
-    it("customLabels", async () => {
-      const ns = await K8s(kind.Namespace).Get("pepr-system")
-      expect(ns.metadata?.labels).toEqual(
-        expect.objectContaining(cfg.pepr.customLabels.namespace)
-      )
-    }, secs(10))
+        expect(mwc.webhooks![0].failurePolicy).toBe(failurePolicy);
+        expect(vwc.webhooks![0].failurePolicy).toBe(failurePolicy);
+      },
+      secs(10),
+    );
 
-    it("env", async () => {
-      const logz = await logs()
-      expect(logz.join("\n")).toMatch(`"ITS":"a bird, a plane, superman"`)
-    }, secs(5))
+    it(
+      "customLabels",
+      async () => {
+        const ns = await K8s(kind.Namespace).Get("pepr-system");
+        expect(ns.metadata?.labels).toEqual(
+          expect.objectContaining(cfg.pepr.customLabels.namespace),
+        );
+      },
+      secs(10),
+    );
 
-    it("alwaysIgnore", async () => {
-      const mutated = await K8s(kind.Namespace).Get("hello-pepr-config")
-      const ignored = await K8s(kind.Namespace).Get("hello-pepr-config-ignore")
+    it(
+      "env",
+      async () => {
+        const logz = await logs();
+        expect(logz.join("\n")).toMatch(`"ITS":"a bird, a plane, superman"`);
+      },
+      secs(5),
+    );
 
-      expect(mutated.metadata?.annotations).toEqual({
-        [`${cfg.pepr.uuid}.pepr.dev/hello-pepr-config`]: 'succeeded',
-        pepr: "was here"
-      })
+    it(
+      "alwaysIgnore",
+      async () => {
+        const mutated = await K8s(kind.Namespace).Get("hello-pepr-config");
+        const ignored = await K8s(kind.Namespace).Get(
+          "hello-pepr-config-ignore",
+        );
 
-      expect(ignored.metadata?.annotations).toBe(undefined)
-    }, secs(10))
-  })
-})
+        expect(mutated.metadata?.annotations).toEqual({
+          [`${cfg.pepr.uuid}.pepr.dev/hello-pepr-config`]: "succeeded",
+          pepr: "was here",
+        });
+
+        expect(ignored.metadata?.annotations).toBe(undefined);
+      },
+      secs(10),
+    );
+
+    it("should only deploy admission manifests if there are no watch bindings", async () => {
+      const controllerDeployments = await K8s(kind.Deployment)
+        .InNamespace("pepr-system")
+        .Get();
+      const controllerServices = await K8s(kind.Service)
+        .InNamespace("pepr-system")
+        .Get();
+
+      expect(controllerDeployments.items.length).toBe(1);
+      expect(controllerDeployments.items[0].metadata?.name).toBe(moduleName);
+      expect(controllerServices.items.length).toBe(1);
+      expect(controllerServices.items[0].metadata?.name).toBe(moduleName);
+    });
+  });
+});

--- a/hello-pepr-watch/capabilities/watch.e2e.test.ts
+++ b/hello-pepr-watch/capabilities/watch.e2e.test.ts
@@ -10,54 +10,84 @@ const trc = new TestRunCfg(__filename);
 
 describe("watch.ts", () => {
   beforeAll(async () => await moduleUp(), mins(4));
-  afterAll(async () => {
-    await moduleDown();
-    await clean(trc);
-  }, mins(2));
+  // afterAll(async () => {
+  //   await moduleDown();
+  //   await clean(trc);
+  // }, mins(2));
 
-  it("watches resource creates", async () => {
-    const file = `${trc.root()}/capabilities/scenario.create.yaml`;
-    const resources = await trc.load(file);
-    await fullCreate(resources, kind);
+  it(
+    "watches resource creates",
+    async () => {
+      const file = `${trc.root()}/capabilities/scenario.create.yaml`;
+      const resources = await trc.load(file);
+      await fullCreate(resources, kind);
 
-    // no direct assertion -- test succeeds when message is logged
-    await untilLogged("Watched create-me: create");
-  }, secs(10));
+      // no direct assertion -- test succeeds when message is logged
+      await untilLogged("Watched create-me: create");
+    },
+    secs(10),
+  );
 
-  it("watches resource create-or-updates", async () => {
-    const file = `${trc.root()}/capabilities/scenario.create-or-update.yaml`;
-    const resources = await trc.load(file);
-    await fullCreate(resources, kind);
-    await untilLogged("Watched create-or-update-me: ADDED");
+  it(
+    "watches resource create-or-updates",
+    async () => {
+      const file = `${trc.root()}/capabilities/scenario.create-or-update.yaml`;
+      const resources = await trc.load(file);
+      await fullCreate(resources, kind);
+      await untilLogged("Watched create-or-update-me: ADDED");
 
-    const update = {...resources.at(-1), stringData: { k: "v" }};
-    await K8s(kind.Secret).Apply(update);
+      const update = { ...resources.at(-1), stringData: { k: "v" } };
+      await K8s(kind.Secret).Apply(update);
 
-    // no direct assertion -- test succeeds when message is logged
-    await untilLogged("Watched create-or-update-me: MODIFIED");
-  }, secs(10));
+      // no direct assertion -- test succeeds when message is logged
+      await untilLogged("Watched create-or-update-me: MODIFIED");
+    },
+    secs(10),
+  );
 
-  it("watches resource updates", async () => {
-    const file = `${trc.root()}/capabilities/scenario.update.yaml`;
-    const resources = await trc.load(file);
-    await fullCreate(resources, kind);
+  it(
+    "watches resource updates",
+    async () => {
+      const file = `${trc.root()}/capabilities/scenario.update.yaml`;
+      const resources = await trc.load(file);
+      await fullCreate(resources, kind);
 
-    const update = {...resources.at(-1), stringData: { k: "v" }};
-    await K8s(kind.Secret).Apply(update);
+      const update = { ...resources.at(-1), stringData: { k: "v" } };
+      await K8s(kind.Secret).Apply(update);
 
-    // no direct assertion -- test succeeds when message is logged
-    await untilLogged("Watched update-me: update");
-  }, secs(10));
+      // no direct assertion -- test succeeds when message is logged
+      await untilLogged("Watched update-me: update");
+    },
+    secs(10),
+  );
 
-  it("watches resource deletes", async () => {
-    const file = `${trc.root()}/capabilities/scenario.delete.yaml`;
-    const resources = await trc.load(file);
-    await fullCreate(resources, kind);
+  it(
+    "watches resource deletes",
+    async () => {
+      const file = `${trc.root()}/capabilities/scenario.delete.yaml`;
+      const resources = await trc.load(file);
+      await fullCreate(resources, kind);
 
-    const { namespace, name } = resources.at(-1).metadata;
-    await K8s(kind.Secret).InNamespace(namespace).Delete(name);
+      const { namespace, name } = resources.at(-1).metadata;
+      await K8s(kind.Secret).InNamespace(namespace).Delete(name);
 
-    // no direct assertion -- test succeeds when message is logged
-    await untilLogged("Watched delete-me: delete");
-  }, secs(10));
+      // no direct assertion -- test succeeds when message is logged
+      await untilLogged("Watched delete-me: delete");
+    },
+    secs(10),
+  );
+
+  it("should only deploy watch manifests if there are no admission bindings", async () => {
+    const controllerDeployments = await K8s(kind.Deployment).InNamespace("pepr-system").Get();
+    const controllerServices = await K8s(kind.Service).InNamespace("pepr-system").Get();
+
+    expect(controllerDeployments.items.length).toBe(1);
+    expect(controllerDeployments.items[0].metadata?.name).toBe(
+      "pepr-2dde1046-4b91-498f-b58f-6b371932e4b6-watcher",
+    );
+    expect(controllerServices.items.length).toBe(1);
+    expect(controllerServices.items[0].metadata?.name).toBe(
+      "pepr-2dde1046-4b91-498f-b58f-6b371932e4b6-watcher",
+    );
+  });
 });


### PR DESCRIPTION
Im support of Pepr PR #[2359](https://github.com/defenseunicorns/pepr/pull/2359) these two new test cases ensure that only admission resources are deploy if the bindings are all admission, and likewise that only watcher resources are deployed for only watches.

This PR requires #337 to be merged in first as the `moduleUp` command is assuming that both controllers will be deployed which is no longer accurate, only the required controllers