### PR TITLE
fix: Use nightly release in PEXEX

### DIFF
--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -94,7 +94,7 @@ export async function untilLogged(needle: string | Function, count = 1) {
 }
 
 export function getPeprAlias(): string {
-  return process.env.PEPR_PACKAGE ? `file:${process.env.PEPR_PACKAGE}` : "pepr@latest";
+  return process.env.PEPR_PACKAGE ? `file:${process.env.PEPR_PACKAGE}` : "pepr@nightly";
 }
 
 export async function peprVersion(): Promise<string> {


### PR DESCRIPTION
In support of #338, we need to use the nightly release of Pepr until the functionality provided by https://github.com/defenseunicorns/pepr/pull/2359 is in a released version of Pepr.