### PR TITLE
fix: use --yes in pepr deploy

### DIFF
--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -151,7 +151,7 @@ export async function moduleUp(
   if (process.env.PEPR_IMAGE) {
     cmd = `npx --yes ${getPeprAlias()} deploy --image=${process.env.PEPR_IMAGE} --confirm`;
   } else {
-    cmd = `npx --yes ${getPeprAlias()} deploy --confirm`;
+    cmd = `npx --yes ${getPeprAlias()} deploy --yes`;
   }
 
   console.time(cmd);


### PR DESCRIPTION
This PR uses `--yes` in support of https://github.com/defenseunicorns/pepr/pull/2382. It must be brought in along with that PR.