### PR TITLE
chore: fix test for pepr ci

### DIFF
--- a/test-specific-version/capabilities/versions.e2e.test.ts
+++ b/test-specific-version/capabilities/versions.e2e.test.ts
@@ -12,7 +12,9 @@ describe("version tests", () => {
       rmSync("node_modules/pepr", { recursive: true, force: true });
       execSync(`npm install pepr@${examplePeprVersion}`);
       const result = execSync(`npx pepr --version`).toString().trim(); //Use a published copy when PEPR_PACKAGE is not set
-      expect(result).toContain(examplePeprVersion);
+      // https://regex101.com/r/7be4fk/1
+      const cleanVersion = examplePeprVersion.replace(/^[~^]/, "");
+      expect(result).toContain(cleanVersion);
     });
   });
   describe("when pepr is a development copy (--local-package or --custom-package)", () => {


### PR DESCRIPTION
This only seems to fail in CI but it is making us force merge

```bash
> npm run test:e2e -w test-specific-version -- --image pepr:dev --custom-package pepr-0.0.0-development.tgz
 RUN  v3.2.4 /Users/cmwylie19/pepr-excellent-examples/test-specific-version

 ✓ capabilities/versions.e2e.test.ts (2 tests) 8347ms
   ✓ version tests (2)
     ✓ when pepr version is defined the example's package.json (v0.51.6) (1)
       ✓ shows the correct version  4436ms
     ✓ when pepr is a development copy (--local-package or --custom-package) (1)
       ✓ shows the correct version  3910ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  09:46:38
   Duration  9.46s (transform 264ms, setup 0ms, collect 592ms, tests 8.35s, environment 0ms, prepare 61ms)
```