### PR TITLE
Use @latest in pexex

### DIFF
--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -94,7 +94,7 @@ export async function untilLogged(needle: string | Function, count = 1) {
 }
 
 export function getPeprAlias(): string {
-  return process.env.PEPR_PACKAGE ? `file:${process.env.PEPR_PACKAGE}` : "pepr@nightly";
+  return process.env.PEPR_PACKAGE ? `file:${process.env.PEPR_PACKAGE}` : "pepr@latest";
 }
 
 export async function peprVersion(): Promise<string> {


### PR DESCRIPTION
Now that the CLI updates have landed, let's test against `@latest` again.