### PR TITLE
remove test_mode envar

### DIFF
--- a/_helpers/src/pepr.e2e.test.ts
+++ b/_helpers/src/pepr.e2e.test.ts
@@ -27,7 +27,7 @@ describe("module lifecycle", () => {
   };
 
   const makeMod = async (mod, ver, verbose = false) => {
-    const env = { TEST_MODE: true, TS_NODE_PROJECT: `${mod}/tsconfig.json` };
+    const env = { TS_NODE_PROJECT: `${mod}/tsconfig.json` };
 
     const cmd = `npx --yes ${getPeprAlias()} init --skip-post-init`;
     console.time(cmd);


### PR DESCRIPTION
Now that 0.52.2 is available, the `TEST_MODE` environment variable has no effect on Pepr. This PR removes it from pexex.