### PR TITLE
Pexex in debug mode

### DIFF
--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -94,7 +94,7 @@ export async function untilLogged(needle: string | Function, count = 1) {
 }
 
 export function getPeprAlias(): string {
-  return process.env.PEPR_PACKAGE ? `file:${process.env.PEPR_PACKAGE}` : "pepr@latest";
+  return process.env.PEPR_PACKAGE ? `file:${process.env.PEPR_PACKAGE}` : "pepr@nightly";
 }
 
 export async function peprVersion(): Promise<string> {

--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -94,7 +94,7 @@ export async function untilLogged(needle: string | Function, count = 1) {
 }
 
 export function getPeprAlias(): string {
-  return process.env.PEPR_PACKAGE ? `file:${process.env.PEPR_PACKAGE}` : "pepr@nightly";
+  return process.env.PEPR_PACKAGE ? `file:${process.env.PEPR_PACKAGE}` : "pepr@latest";
 }
 
 export async function peprVersion(): Promise<string> {

--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -149,9 +149,9 @@ export async function moduleUp(
   await moduleBuild({ version, verbose, rbacMode });
 
   if (process.env.PEPR_IMAGE) {
-    cmd = `npx --yes ${getPeprAlias()} deploy --image=${process.env.PEPR_IMAGE} --yes`;
+    cmd = `LOG_LEVEL=debug npx --yes ${getPeprAlias()} deploy --image=${process.env.PEPR_IMAGE} --yes`;
   } else {
-    cmd = `npx --yes ${getPeprAlias()} deploy --yes`;
+    cmd = `LOG_LEVEL=debug npx --yes ${getPeprAlias()} deploy --yes`;
   }
 
   console.time(cmd);
@@ -161,7 +161,7 @@ export async function moduleUp(
   }
   console.timeEnd(cmd);
 
-  await untilLogged("✅ Controller startup complete", times);
+  await untilLogged("Controller startup complete", times);
   console.timeEnd(`pepr@${version} ready (total time)`);
 }
 


### PR DESCRIPTION
In support of https://github.com/defenseunicorns/pepr/pull/2494

- remove emoji logs so timeout does not occur
- runs `npx pepr deploy` with `LOG_LEVEL=debug`

```bash
> npm run test:e2e -w hello-pepr-store -- --image pepr:dev --custom-package pepr-0.0.0-development.tgz

 ✓ capabilities/store.e2e.test.ts (5 tests) 84847ms
   ✓ store.ts (5)
     ✓ module default store (5)
       ✓ data injection (2)
         ✓ can insert in onReady hook 1ms
         ✓ can clear in onReady hook 0ms
       ✓ asynchronous interaction (1)
         ✓ key can be written, read, and removed 1ms
       ✓ synchronous interaction (1)
         ✓ key can be written, read, and removed 0ms
       ✓ observed interaction (1)
         ✓ sees batched update 1ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  14:48:53
```