### PR TITLE
Rbac mode scoped

### DIFF
--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -94,7 +94,7 @@ export async function untilLogged(needle: string | Function, count = 1) {
 }
 
 export function getPeprAlias(): string {
-  return process.env.PEPR_PACKAGE ? `file:${process.env.PEPR_PACKAGE}` : "pepr@nightly";
+  return process.env.PEPR_PACKAGE ? `file:${process.env.PEPR_PACKAGE}` : "pepr@latest";
 }
 
 export async function peprVersion(): Promise<string> {

--- a/hello-pepr-watch/capabilities/watch.e2e.test.ts
+++ b/hello-pepr-watch/capabilities/watch.e2e.test.ts
@@ -90,4 +90,28 @@ describe("watch.ts", () => {
       "pepr-2dde1046-4b91-498f-b58f-6b371932e4b6-watcher",
     );
   });
+
+  it("should create the clusterolebinding in scoped mode", async () => {
+    const clusterRole = await K8s(kind.ClusterRole).Get(
+      "pepr-2dde1046-4b91-498f-b58f-6b371932e4b6",
+    );
+    expect(clusterRole).toBeDefined();
+
+    const secretWatchRule = clusterRole.rules?.find(rule => rule.resources?.[0] === "secrets");
+    expect(secretWatchRule).toBeDefined();
+    expect(secretWatchRule?.apiGroups?.[0]).toBe("");
+    expect(secretWatchRule?.verbs?.includes("watch")).toBe(true);
+
+    const configMapWatchRule = clusterRole.rules?.find(
+      rule => rule.resources?.[0] === "configmaps",
+    );
+    expect(configMapWatchRule).toBeDefined();
+    expect(configMapWatchRule?.apiGroups?.[0]).toBe("");
+    expect(configMapWatchRule?.verbs?.includes("watch")).toBe(true);
+
+    const podWatchRule = clusterRole.rules?.find(rule => rule.resources?.[0] === "pods");
+    expect(podWatchRule).toBeDefined();
+    expect(podWatchRule?.apiGroups?.[0]).toBe("");
+    expect(podWatchRule?.verbs?.includes("watch")).toBe(true);
+  });
 });

--- a/hello-pepr-watch/capabilities/watch.ts
+++ b/hello-pepr-watch/capabilities/watch.ts
@@ -9,12 +9,25 @@ export const HelloPeprWatch = new Capability({
 });
 
 const { When } = HelloPeprWatch;
-
+When(a.Pod)
+  .IsCreated()
+  .InNamespace(name)
+  .WithName("create-me")
+  .Watch(instance => {
+    Log.info(`Watched ${instance.metadata?.name}: create`);
+  });
+When(a.ConfigMap)
+  .IsCreated()
+  .InNamespace(name)
+  .WithName("create-me")
+  .Watch(instance => {
+    Log.info(`Watched ${instance.metadata?.name}: create`);
+  });
 When(a.Secret)
   .IsCreated()
   .InNamespace(name)
   .WithName("create-me")
-  .Watch((instance) => {
+  .Watch(instance => {
     Log.info(`Watched ${instance.metadata?.name}: create`);
   });
 
@@ -30,7 +43,7 @@ When(a.Secret)
   .IsUpdated()
   .InNamespace(name)
   .WithName("update-me")
-  .Watch((instance) => {
+  .Watch(instance => {
     Log.info(`Watched ${instance.metadata?.name}: update`);
   });
 
@@ -38,6 +51,6 @@ When(a.Secret)
   .IsDeleted()
   .InNamespace(name)
   .WithName("delete-me")
-  .Watch((instance) => {
+  .Watch(instance => {
     Log.info(`Watched ${instance.metadata?.name}: delete`);
   });

--- a/hello-pepr-watch/package.json
+++ b/hello-pepr-watch/package.json
@@ -15,6 +15,7 @@
   "pepr": {
     "uuid": "2dde1046-4b91-498f-b58f-6b371932e4b6",
     "onError": "reject",
+    "rbacMode": "scoped",
     "webhookTimeout": 10,
     "customLabels": {
       "namespace": {


### PR DESCRIPTION
In this [document](https://docs.google.com/spreadsheets/d/1ZrJ-CHtZFLx3YDrGs3AjJUe_10EKmDavRcPBzHVLC2Y/edit?gid=0#gid=0) #2 shows that we need to cover rbacMode === scoped build. This tests looks at the cluster role binding and ensures that there is RBAC in order to watch resources.