### PR TITLE
chore: migration test

### DIFF
--- a/hello-pepr-eslint-v10-migration/capabilities/eslint-migration.ts
+++ b/hello-pepr-eslint-v10-migration/capabilities/eslint-migration.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { Capability, a } from "pepr";
+
+export const EslintMigration = new Capability({
+  name: "eslint-migration",
+  description: "Minimal capability used to test pepr format across eslint v9 -> v10 migration",
+  namespaces: [],
+});
+
+const { When } = EslintMigration;
+
+When(a.ConfigMap)
+  .IsCreated()
+  .Mutate(cm => {
+    cm.SetLabel("pepr.dev/eslint-migration", "true");
+  });

--- a/hello-pepr-eslint-v10-migration/eslint.config.mjs
+++ b/hello-pepr-eslint-v10-migration/eslint.config.mjs
@@ -1,0 +1,48 @@
+// This is intentionally the OLD (v9-era) eslint config format that pepr init generated
+// before the eslint v10 migration. It uses FlatCompat + __dirname. The migration test
+// verifies that pepr format passes with both eslint v9 (old pepr) and eslint v10 (new pepr).
+import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
+import globals from "globals";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
+});
+
+export default [
+  {
+    ignores: ["**/node_modules", "**/dist"],
+  },
+  ...compat.extends("eslint:recommended", "plugin:@typescript-eslint/recommended"),
+  {
+    plugins: {
+      "@typescript-eslint": typescriptEslint,
+    },
+
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: ["eslint.config.mjs"],
+        },
+        tsconfigRootDir: __dirname,
+        sourceType: "module",
+      },
+      globals: {
+        ...globals.node,
+      },
+    },
+
+    rules: {
+      "@typescript-eslint/no-floating-promises": "error",
+    },
+  },
+];

--- a/hello-pepr-eslint-v10-migration/eslint.config.mjs
+++ b/hello-pepr-eslint-v10-migration/eslint.config.mjs
@@ -1,6 +1,6 @@
 // This is intentionally the OLD (v9-era) eslint config format that pepr init generated
 // before the eslint v10 migration. It uses FlatCompat + __dirname. The migration test
-// verifies that pepr format passes with both eslint v9 (old pepr) and eslint v10 (new pepr).
+// verifies that pepr format passes with eslint v10 (new pepr) against this unchanged config.
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
 import path from "node:path";

--- a/hello-pepr-eslint-v10-migration/package.json
+++ b/hello-pepr-eslint-v10-migration/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "hello-pepr-eslint-v10-migration",
+  "version": "0.0.1",
+  "description": "Tests that pepr format works before and after the eslint v9 -> v10 migration",
+  "keywords": [
+    "pepr",
+    "k8s",
+    "policy-engine",
+    "pepr-module",
+    "security"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "pepr": {
+    "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "onError": "reject",
+    "alwaysIgnore": {
+      "namespaces": [],
+      "labels": []
+    },
+    "includedFiles": []
+  },
+  "dependencies": {
+    "pepr": "1.1.5"
+  },
+  "devDependencies": {
+    "typescript": "6.0.2"
+  },
+  "scripts": {
+    "cli": "npm run --workspace helpers cli -- --module=$(pwd)",
+    "test:e2e": "node test-format-migration.mjs"
+  }
+}

--- a/hello-pepr-eslint-v10-migration/pepr.ts
+++ b/hello-pepr-eslint-v10-migration/pepr.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2023-Present The Pepr Authors
+
+import { PeprModule } from "pepr";
+import cfg from "./package.json";
+
+import { EslintMigration } from "./capabilities/eslint-migration";
+
+new PeprModule(cfg, [EslintMigration]);

--- a/hello-pepr-eslint-v10-migration/test-format-migration.mjs
+++ b/hello-pepr-eslint-v10-migration/test-format-migration.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// One-time pre-release validation for the eslint v9 -> v10 migration in pepr.
+// Run this locally before cutting the release to confirm that the old (v9-era, FlatCompat)
+// eslint.config.mjs — which existing user modules will still have after upgrading pepr —
+// continues to pass `pepr format` under the new pepr version that ships eslint v10.
+// Once the release is validated and shipped, this branch can be deleted.
+//
+// Requires PEPR_CANDIDATE to be set. To test, from hello-pepr-eslint-v10-migration directory, run:
+//   local:  PEPR_CANDIDATE=file:../../pepr node test-format-migration.mjs
+//           (requires `npm run build` in the pepr repo first)
+//   tagged: PEPR_CANDIDATE=1.2.0 node test-format-migration.mjs
+
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+function run(cmd) {
+  console.log(`\n$ ${cmd}`);
+  execSync(cmd, { cwd: moduleDir, stdio: "inherit" });
+}
+
+function peprCli(installRoot) {
+  return path.join(installRoot, "node_modules", "pepr", "dist", "cli.js");
+}
+
+const candidate = process.env.PEPR_CANDIDATE;
+if (!candidate) {
+  console.error(`
+PEPR_CANDIDATE is required.
+  local:  PEPR_CANDIDATE=file:../../pepr node test-format-migration.mjs
+  tagged: PEPR_CANDIDATE=1.2.0 node test-format-migration.mjs
+`);
+  process.exit(1);
+}
+
+let tmpDir = null;
+let cli;
+
+if (candidate.startsWith("file:")) {
+  const localPath = path.resolve(moduleDir, candidate.slice("file:".length));
+  cli = path.join(localPath, "dist", "cli.js");
+  if (!existsSync(cli)) {
+    console.error(`candidate CLI not found at ${cli} — run npm run build in the pepr repo first`);
+    process.exit(1);
+  }
+} else {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), "pepr-migration-candidate-"));
+  try {
+    execSync(`npm install --prefix "${tmpDir}" pepr@${candidate}`, { stdio: "inherit" });
+  } catch (e) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    console.error(`Failed to install pepr@${candidate}: ${e.message}`);
+    process.exit(1);
+  }
+  cli = peprCli(tmpDir);
+}
+
+try {
+  run(`node "${cli}" format`);
+  console.log("\n✓ pepr format passed with eslint v10 candidate");
+} finally {
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+}

--- a/hello-pepr-eslint-v10-migration/tsconfig.json
+++ b/hello-pepr-eslint-v10-migration/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "rootDir": ".",
+    "strict": false,
+    "target": "ES2022",
+    "useUnknownInCatchVariables": false
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.test.*", "./dist/**/*", "./dev/**/*"]
+}


### PR DESCRIPTION
Test to make sure the current format is compatible with ESLint v10.  This test/branch is intended for closing without merge.

To test:
Local- eslint v10 - 
     1. Build Pepr locally from Pepr branch 'eslint-testing' in Pepr [PR #2983](https://github.com/defenseunicorns/pepr/pull/2983)
     2. From the `hello-pepr-eslint-v10-migration` directory on this branch, run: PEPR_CANDIDATE=file:<path-to-local-pepr> node test-format-migration.mjs
     
Versioned- eslint v9-
      1. Run PEPR_CANDIDATE=1.1.5 node test-format-migration.mjs
