### PR TITLE
fix(_helpers): rewrite workspace pepr pins to file: spec before install

### DIFF
--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -103,16 +103,18 @@ program.command('test')
     // pepr pin to the same `file:` spec so npm resolves a single pepr
     // version across the whole workspace tree. Without this, workspaces'
     // hard-pinned pepr@X.Y.Z conflicts with the dev tarball at install.
-    if (process.env.PEPR_PACKAGE) {
-      rewriteWorkspacePeprPins(peprExcellentExamplesRepo, getPeprAlias().replace(/^pepr@/, ""));
-      execSync(`npm install ${process.env.PEPR_PACKAGE}`, { cwd: peprExcellentExamplesRepo });
-    }
-
     try {
+      if (process.env.PEPR_PACKAGE) {
+        rewriteWorkspacePeprPins(peprExcellentExamplesRepo, `file:${process.env.PEPR_PACKAGE}`);
+        execSync(`npm install ${process.env.PEPR_PACKAGE}`, { cwd: peprExcellentExamplesRepo });
+      }
       process.env.KFC_PACKAGE = thisCommand.opts().kfc
       backupPackageJSON();
       execSync('npm install', { cwd: peprExcellentExamplesRepo });
     } catch (err) {
+      if (process.env.CI !== 'true') {
+        restoreWorkspacePeprPins(peprExcellentExamplesRepo);
+      }
       throw new Error(`Failed to run npm install in ${peprExcellentExamplesRepo}. Check package.json and package-lock.json. Error: ${err.message}`);
     }
 

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -8,6 +8,7 @@ import { writer } from '../src/deps/writer';
 import { up, down } from '../src/cluster';
 import { findUpSync } from 'find-up'
 import { getPeprAlias } from '../src/pepr'
+import { rewriteWorkspacePeprPins, restoreWorkspacePeprPins } from '../src/peprPins'
 import { copyFileSync, mkdirSync, renameSync, rmSync } from 'fs';
 import { rmdirSync } from 'node:fs';
 import assert from 'node:assert';
@@ -88,8 +89,6 @@ program.command('test')
     if (thisCommand.opts().suite === "unit" ){ return }
 
     if (thisCommand.opts().customPackage){
-      // install the custom package at the root
-      execSync(`npm install ${thisCommand.opts().customPackage}`, { cwd: peprExcellentExamplesRepo });
       process.env.PEPR_PACKAGE = `${resolve(peprExcellentExamplesRepo, thisCommand.opts().customPackage)}`
       validateCustomPackage(peprExcellentExamplesRepo);
     }
@@ -98,6 +97,15 @@ program.command('test')
     }
     if (thisCommand.opts().image){
       process.env.PEPR_IMAGE = thisCommand.opts().image
+    }
+
+    // When PEPR_PACKAGE points at a tarball, rewrite every workspace's
+    // pepr pin to the same `file:` spec so npm resolves a single pepr
+    // version across the whole workspace tree. Without this, workspaces'
+    // hard-pinned pepr@X.Y.Z conflicts with the dev tarball at install.
+    if (process.env.PEPR_PACKAGE) {
+      rewriteWorkspacePeprPins(peprExcellentExamplesRepo, getPeprAlias().replace(/^pepr@/, ""));
+      execSync(`npm install ${process.env.PEPR_PACKAGE}`, { cwd: peprExcellentExamplesRepo });
     }
 
     try {
@@ -122,6 +130,7 @@ program.command('test')
     finally{
       if(process.env.CI !== 'true') {
         restorePackageJSON();
+        restoreWorkspacePeprPins(peprExcellentExamplesRepo);
       }
     }
   })

--- a/_helpers/src/peprPins.ts
+++ b/_helpers/src/peprPins.ts
@@ -1,0 +1,70 @@
+import { copyFileSync, existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const BACKUP_SUFFIX = ".peprPin.bak";
+const DEP_BLOCKS = ["dependencies", "devDependencies", "peerDependencies"] as const;
+
+interface PackageJson {
+  workspaces?: string[];
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+const readJson = (path: string): PackageJson => JSON.parse(readFileSync(path, "utf8"));
+
+const writeJson = (path: string, content: PackageJson) =>
+  writeFileSync(path, JSON.stringify(content, null, 2) + "\n");
+
+const listWorkspaces = (rootDir: string): string[] => {
+  const rootPkg = readJson(join(rootDir, "package.json"));
+  return rootPkg.workspaces ?? [];
+};
+
+/**
+ * Rewrites every workspace's `pepr` dependency entry (across `dependencies`,
+ * `devDependencies`, and `peerDependencies`) to `peprSpec`, leaving a sidecar
+ * backup at `<workspace>/package.json.peprPin.bak`. The original file is
+ * preserved untouched on first call; subsequent calls overwrite the package.json
+ * but never replace an existing backup, so `restoreWorkspacePeprPins` can always
+ * recover the pre-rewrite state.
+ */
+export function rewriteWorkspacePeprPins(rootDir: string, peprSpec: string): string[] {
+  const rewritten: string[] = [];
+
+  for (const ws of listWorkspaces(rootDir)) {
+    const pkgPath = join(rootDir, ws, "package.json");
+    if (!existsSync(pkgPath)) continue;
+
+    const pkg = readJson(pkgPath);
+    const blocksWithPepr = DEP_BLOCKS.filter(b => pkg[b]?.pepr !== undefined);
+    if (blocksWithPepr.length === 0) continue;
+
+    const backupPath = pkgPath + BACKUP_SUFFIX;
+    if (!existsSync(backupPath)) {
+      copyFileSync(pkgPath, backupPath);
+    }
+
+    for (const block of blocksWithPepr) {
+      pkg[block]!.pepr = peprSpec;
+    }
+    writeJson(pkgPath, pkg);
+    rewritten.push(ws);
+  }
+
+  return rewritten;
+}
+
+export function restoreWorkspacePeprPins(rootDir: string): string[] {
+  const restored: string[] = [];
+
+  for (const ws of listWorkspaces(rootDir)) {
+    const backupPath = join(rootDir, ws, "package.json" + BACKUP_SUFFIX);
+    if (!existsSync(backupPath)) continue;
+    renameSync(backupPath, join(rootDir, ws, "package.json"));
+    restored.push(ws);
+  }
+
+  return restored;
+}

--- a/_helpers/src/peprPins.unit.test.ts
+++ b/_helpers/src/peprPins.unit.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as pfs from "fs/promises";
+import * as os from "os";
+import { existsSync } from "fs";
+import { rewriteWorkspacePeprPins, restoreWorkspacePeprPins } from "./peprPins";
+
+const writeJson = async (path: string, content: object) =>
+  pfs.writeFile(path, JSON.stringify(content, null, 2) + "\n");
+
+const readJson = async (path: string) => JSON.parse(await pfs.readFile(path, "utf8"));
+
+describe("peprPins", () => {
+  let rootDir: string;
+
+  beforeEach(async () => {
+    rootDir = await pfs.mkdtemp(`${os.tmpdir()}/peprPins-`);
+    await writeJson(`${rootDir}/package.json`, {
+      name: "fixture-root",
+      workspaces: ["wsA", "wsB", "wsC", "wsDev", "_helpers", "missing-on-disk"],
+    });
+    await pfs.mkdir(`${rootDir}/wsA`, { recursive: true });
+    await pfs.mkdir(`${rootDir}/wsB`, { recursive: true });
+    await pfs.mkdir(`${rootDir}/wsC`, { recursive: true });
+    await pfs.mkdir(`${rootDir}/wsDev`, { recursive: true });
+    await pfs.mkdir(`${rootDir}/_helpers`, { recursive: true });
+
+    await writeJson(`${rootDir}/wsA/package.json`, {
+      name: "wsA",
+      dependencies: { pepr: "1.1.5", "kubernetes-fluent-client": "^3.0.0" },
+      devDependencies: { typescript: "5.8.3" },
+    });
+    await writeJson(`${rootDir}/wsB/package.json`, {
+      name: "wsB",
+      devDependencies: { typescript: "5.8.3" },
+    });
+    await writeJson(`${rootDir}/wsC/package.json`, {
+      name: "wsC",
+      peerDependencies: { pepr: "^1.0.0" },
+    });
+    await writeJson(`${rootDir}/wsDev/package.json`, {
+      name: "wsDev",
+      devDependencies: { pepr: "1.0.0" },
+    });
+    await writeJson(`${rootDir}/_helpers/package.json`, {
+      name: "helpers",
+      devDependencies: { vitest: "*" },
+    });
+  });
+
+  afterEach(async () => {
+    await pfs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  describe("rewriteWorkspacePeprPins()", () => {
+    it("rewrites `pepr` in dependencies and creates a sidecar backup", async () => {
+      const rewritten = rewriteWorkspacePeprPins(rootDir, "file:/tmp/p.tgz");
+
+      expect(rewritten).toEqual(expect.arrayContaining(["wsA"]));
+
+      const updated = await readJson(`${rootDir}/wsA/package.json`);
+      expect(updated.dependencies.pepr).toBe("file:/tmp/p.tgz");
+      expect(updated.dependencies["kubernetes-fluent-client"]).toBe("^3.0.0");
+      expect(updated.devDependencies.typescript).toBe("5.8.3");
+
+      const backup = await readJson(`${rootDir}/wsA/package.json.peprPin.bak`);
+      expect(backup.dependencies.pepr).toBe("1.1.5");
+    });
+
+    it("rewrites `pepr` in peerDependencies", async () => {
+      rewriteWorkspacePeprPins(rootDir, "file:/tmp/p.tgz");
+      const updated = await readJson(`${rootDir}/wsC/package.json`);
+      expect(updated.peerDependencies.pepr).toBe("file:/tmp/p.tgz");
+    });
+
+    it("rewrites `pepr` in devDependencies", async () => {
+      rewriteWorkspacePeprPins(rootDir, "latest");
+      const updated = await readJson(`${rootDir}/wsDev/package.json`);
+      expect(updated.devDependencies.pepr).toBe("latest");
+    });
+
+    it("skips workspaces without a `pepr` dep entry", async () => {
+      const rewritten = rewriteWorkspacePeprPins(rootDir, "file:/tmp/p.tgz");
+      expect(rewritten).not.toContain("wsB");
+      expect(rewritten).not.toContain("_helpers");
+      expect(existsSync(`${rootDir}/wsB/package.json.peprPin.bak`)).toBe(false);
+      expect(existsSync(`${rootDir}/_helpers/package.json.peprPin.bak`)).toBe(false);
+    });
+
+    it("ignores workspaces whose dir or package.json is missing", () => {
+      const rewritten = rewriteWorkspacePeprPins(rootDir, "file:/tmp/p.tgz");
+      expect(rewritten).not.toContain("missing-on-disk");
+    });
+
+    it("returns the list of rewritten workspaces", () => {
+      const rewritten = rewriteWorkspacePeprPins(rootDir, "file:/tmp/p.tgz");
+      expect(rewritten.sort()).toEqual(["wsA", "wsC", "wsDev"]);
+    });
+
+    it("is idempotent — second call does not stomp the original backup", async () => {
+      rewriteWorkspacePeprPins(rootDir, "file:/tmp/first.tgz");
+      const firstBackup = await readJson(`${rootDir}/wsA/package.json.peprPin.bak`);
+      rewriteWorkspacePeprPins(rootDir, "file:/tmp/second.tgz");
+      const secondBackup = await readJson(`${rootDir}/wsA/package.json.peprPin.bak`);
+      expect(secondBackup.dependencies.pepr).toBe(firstBackup.dependencies.pepr);
+      expect(secondBackup.dependencies.pepr).toBe("1.1.5");
+
+      const updated = await readJson(`${rootDir}/wsA/package.json`);
+      expect(updated.dependencies.pepr).toBe("file:/tmp/second.tgz");
+    });
+  });
+
+  describe("restoreWorkspacePeprPins()", () => {
+    it("restores files from sidecar backups", async () => {
+      rewriteWorkspacePeprPins(rootDir, "file:/tmp/p.tgz");
+      const restored = restoreWorkspacePeprPins(rootDir);
+
+      expect(restored.sort()).toEqual(["wsA", "wsC", "wsDev"]);
+
+      const wsA = await readJson(`${rootDir}/wsA/package.json`);
+      expect(wsA.dependencies.pepr).toBe("1.1.5");
+      expect(existsSync(`${rootDir}/wsA/package.json.peprPin.bak`)).toBe(false);
+
+      const wsC = await readJson(`${rootDir}/wsC/package.json`);
+      expect(wsC.peerDependencies.pepr).toBe("^1.0.0");
+    });
+
+    it("returns an empty list when nothing was rewritten", () => {
+      const restored = restoreWorkspacePeprPins(rootDir);
+      expect(restored).toEqual([]);
+    });
+
+    it("does not touch workspaces without a backup", async () => {
+      rewriteWorkspacePeprPins(rootDir, "file:/tmp/p.tgz");
+      restoreWorkspacePeprPins(rootDir);
+      const wsB = await readJson(`${rootDir}/wsB/package.json`);
+      expect(wsB.devDependencies.typescript).toBe("5.8.3");
+      expect(wsB).not.toHaveProperty("dependencies.pepr");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a small workspace-pin rewrite step to `_helpers/dev/cli.mts` so that every `hello-pepr-*` workspace's hard-pinned `pepr` dependency is temporarily replaced with a `file:` spec pointing at the candidate tarball before `npm install` runs, and restored after the test suite. Without this, the workspaces' `pepr@<release>` pins conflict with the `pepr@0.0.0-development` tarball that `--custom-package` / `--local-package` injects, and `npm install` fails with `ERESOLVE` before any e2e test can start.

Closes #490.

## What changed

- **New module** `_helpers/src/peprPins.ts` — `rewriteWorkspacePeprPins(rootDir, peprSpec)` reads the root `package.json`, walks every workspace, and rewrites any `pepr` entry across `dependencies` / `devDependencies` / `peerDependencies` to `peprSpec`. Original files are preserved as `<workspace>/package.json.peprPin.bak` sidecars. `restoreWorkspacePeprPins(rootDir)` reverses the rewrite. The functions are idempotent: a second `rewrite` call never stomps the original backup, so `restore` always recovers the pre-rewrite state.
- **New tests** `_helpers/src/peprPins.unit.test.ts` — 10 vitest cases covering the three dep blocks, idempotency, missing-workspace skipping, and round-trip restoration.
- **`_helpers/dev/cli.mts`** — 10-line wire-up:
  - When `process.env.PEPR_PACKAGE` is set (i.e. `--custom-package` or `--local-package` was passed), call `rewriteWorkspacePeprPins(...)` *before* the root `npm install` so the workspace tree resolves to a single pepr version.
  - In the action's `finally`, call `restoreWorkspacePeprPins(...)` (gated on `CI !== 'true'`, mirroring the existing `restorePackageJSON` behavior).

## Why `file:` specifically

`pepr@0.0.0-development` is a real (deprecated) registry entry. Without a `file:` spec, a partial cache hit could silently resolve to the deprecated registry version rather than the candidate tarball. `file:` paths bypass the registry entirely. This matches the convention already used elsewhere in this repo for candidate-version swap-in.

## Test plan

- [x] `npm test` in `_helpers/` — all 10 new `peprPins.unit.test.ts` cases pass; pre-existing failures (`Cmd.unit.test.ts` `/tmp` macOS symlink, `pepr.e2e.test.ts` cluster lifecycle) unrelated.
- [x] Smoke test against real pexex workspaces: rewrites all 31 `hello-pepr-*` workspaces' `pepr` pins to a `file:` spec and restores them cleanly to the originals.
- [x] End-to-end install verification: `npm install <pepr-dev-tarball>` from pexex root after rewrite — the previously-blocking pepr-version `ERESOLVE` is gone. (A separate `typescript` peer-dep mismatch is the next cascade layer; tracked separately.)

## Out of scope / follow-up

The same end-to-end test surfaces a `typescript` peer-dep mismatch between pepr's bumped `^6.0.3` peer (defenseunicorns/pepr#3093) and pexex's `5.8.3` devDep pin in `_helpers/package.json` and every `hello-pepr-*/package.json`. That requires a coordinated bump in pexex (or widening pepr's range) and is intentionally not addressed here. Filed/tracked separately so this PR stays focused on the workspace-pin injection mechanism.
