### PR TITLE
chore: major version bump excluded from group prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,14 @@ updates:
     groups:
       prod:
         dependency-type: "production"
+        update-types: 
+          - "minor"
+          - "patch"
       dev:
         dependency-type: "development"
+        update-types: 
+          - "minor"
+          - "patch"
 
     allow:
       - dependency-type: "production"


### PR DESCRIPTION
Major version bumps often bring breaking changes. Currently, the major, minor, and patch bumps are all grouped in the same Dependabot PR. This change will keep the minor/patch changes in group PRs but force[ major updates into standalone PRs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#:~:text=Any%20outdated%20dependencies%20that%20do%20not%20match%20a%20rule%20are%20updated%20in%20individual%20pull%20requests).