### PR TITLE
chore: added new dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,14 @@ updates:
         update-types: 
           - "minor"
           - "patch"
+      prod-major:
+        dependency-type: "production"
+        update-types: 
+          - "major"
+      dev-major:
+        dependency-type: "development"
+        update-types: 
+          - "major"
 
     allow:
       - dependency-type: "production"


### PR DESCRIPTION
Added new dependabot groups so major version updates are grouped together in the same dependabot PR. Related to #497 