### PR TITLE
chore: update helpers e2e path and flags

### DIFF
--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -209,7 +209,7 @@ function testUnit(passthru) {
       "--passWithNoTests",
       "--reporter", "verbose",
       ...passthru,
-      ".*\\.unit\\.test\\.ts",
+      "unit.test.ts",
     ],
     { stdio: 'inherit' }
   )
@@ -234,10 +234,9 @@ async function testE2e(passthru) {
     const result = spawnSync(
       "vitest", [
         "run",
-        "--passWithNoTests",
         "--reporter", "verbose",
         ...passthru,
-         "src/cluster\\.e2e\\.test\\.ts",
+         "src/cluster.e2e.test.ts",
       ],
       { stdio: 'inherit' }
     )
@@ -252,10 +251,9 @@ async function testE2e(passthru) {
       const result = spawnSync(
         "vitest", [
           "run",
-          "--passWithNoTests",
           "--reporter", "verbose",
           ...passthru,
-          "src/cluster\\.e2e\\.test\\.ts",
+          "src/cluster.e2e.test.ts",
         ],
         {
           stdio: 'inherit',

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -206,7 +206,6 @@ function testUnit(passthru) {
      
     "vitest", [
       "run",
-      "--passWithNoTests",
       "--reporter", "verbose",
       ...passthru,
       "unit.test.ts",
@@ -273,7 +272,6 @@ async function testE2e(passthru) {
       const result = spawnSync(
         "vitest", [
           "run",
-          "--passWithNoTests",
           "--reporter", "verbose",
           ...passthru
 


### PR DESCRIPTION
  - Fix 3 Vitest filter patterns broken by #461, which converted no-op string escapes (\.) into literal backslashes (\\.) that don't match any file paths 
  - Remove `--passWithNoTests` from all vitest calls — it masked the bug by silently passing with zero tests 
 
Vitest CLI filters use String.includes(), not regex. #461  ESLint no-useless-escape fix introduced literal `\` characters into the filter strings, so they stopped matching. `--passWithNoTests` (added without justification in [ec2c333](https://github.com/defenseunicorns/pepr-excellent-examples/commit/ec2c333a9d784da34b2a7269a27b3cccac4f0ff3)) hid the failure.   