### PR TITLE
fix(hello-pepr-finalize): strip finalizers in afterAll to unblock cleanup

### DIFF
--- a/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
+++ b/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
@@ -133,8 +133,11 @@ describe("finalize.ts", () => {
     await stripFinalizers();
     await clean(trc);
     await stripPeprSystemFinalizers();
-    await dumpPeprSystem();
     await moduleDownBounded(45);
+    // Dump AFTER moduleDown timed out — pepr-system should now be in
+    // Terminating phase with status.conditions naming the actual blocker
+    // (NamespaceContentRemaining, NamespaceFinalizersRemaining, etc.).
+    await dumpPeprSystem();
   }, mins(2));
 
   describe("create", () => {

--- a/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
+++ b/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
@@ -66,53 +66,12 @@ async function stripPeprSystemFinalizers(): Promise<void> {
   }
 }
 
-// Diagnostic dump: log everything in pepr-system at teardown time so we
-// can identify what's actually holding the namespace in Terminating.
-// Runs right before moduleDown(). Best-effort — never throws.
-async function dumpPeprSystem(): Promise<void> {
-  const ns = "pepr-system";
-  console.log(`[diag] === pepr-system teardown snapshot ===`);
-  try {
-    const got = await K8s(kind.Namespace).Get(ns);
-    console.log(
-      `[diag] namespace phase=${got.status?.phase} conditions=${JSON.stringify(
-        got.status?.conditions ?? [],
-      )} finalizers=${JSON.stringify(got.spec?.finalizers ?? [])}`,
-    );
-  } catch (e) {
-    console.log(`[diag] namespace Get failed: status=${e.status}`);
-  }
-
-  const kinds: Array<[string, any]> = [
-    ["ConfigMap", kind.ConfigMap],
-    ["Secret", kind.Secret],
-    ["Pod", kind.Pod],
-    ["Service", kind.Service],
-    ["Deployment", kind.Deployment],
-    ["ServiceAccount", kind.ServiceAccount],
-  ];
-  for (const [label, k] of kinds) {
-    try {
-      const list = await K8s(k).InNamespace(ns).Get();
-      for (const obj of list.items) {
-        const fins = obj.metadata?.finalizers ?? [];
-        const dt = obj.metadata?.deletionTimestamp;
-        console.log(
-          `[diag] ${label}/${obj.metadata?.name} finalizers=${JSON.stringify(fins)} deletionTimestamp=${dt ?? "none"}`,
-        );
-      }
-    } catch (e) {
-      console.log(`[diag] ${label} list failed: status=${e.status}`);
-    }
-  }
-  console.log(`[diag] === end snapshot ===`);
-}
-
-// Bound moduleDown() so afterAll can complete even if pepr-system stays
-// stuck Terminating. The CI job's k3d cluster is destroyed when the job
-// ends, so leaving residual Pepr artifacts is harmless. NOT the same as
-// raising vitest's hookTimeout — that would just wait longer for the
-// same hang; this gives up on the wait and lets the hook exit cleanly.
+// Bound moduleDown() so afterAll can complete even when pepr-system
+// takes longer than vitest's hookTimeout to fully terminate on a
+// constrained k3d cluster. The CI job's cluster is destroyed at job
+// end, so a not-fully-completed moduleDown is harmless. NOT the same
+// as raising the hookTimeout — that just waits longer for the same
+// hang; this gives up on the wait so the hook exits cleanly.
 async function moduleDownBounded(budgetSecs: number): Promise<void> {
   const result = await Promise.race([
     moduleDown().then(() => "done" as const),
@@ -122,7 +81,7 @@ async function moduleDownBounded(budgetSecs: number): Promise<void> {
   ]);
   if (result === "timeout") {
     console.warn(
-      `[diag] moduleDown() exceeded ${budgetSecs}s; proceeding so afterAll can complete`,
+      `moduleDown() exceeded ${budgetSecs}s; proceeding so afterAll can complete`,
     );
   }
 }
@@ -133,21 +92,6 @@ describe("finalize.ts", () => {
     await stripFinalizers();
     await clean(trc);
     await stripPeprSystemFinalizers();
-
-    // Delete pepr-system ourselves so we can dump it mid-Terminating —
-    // status.conditions populate within a few seconds and name the
-    // actual blocker (NamespaceContentRemaining etc.). Doing this
-    // before moduleDown also avoids the cascading CRD/webhook deletes
-    // that destabilize apiserver discovery (status=400 on subsequent
-    // KFC calls, observed in the prior CI run).
-    try {
-      await K8s(kind.Namespace).Delete("pepr-system");
-    } catch (e) {
-      if (e.status !== 404) throw e;
-    }
-    await new Promise(r => setTimeout(r, 5000));
-    await dumpPeprSystem();
-
     await moduleDownBounded(45);
   }, mins(2));
 

--- a/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
+++ b/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
@@ -9,9 +9,42 @@ import { KubernetesObject } from "kubernetes-fluent-client";
 
 const trc = new TestRunCfg(__filename);
 
+const FINALIZER = "pepr.dev/finalizer";
+const TEST_NAMESPACES = [
+  "hello-pepr-finalize-create",
+  "hello-pepr-finalize-createorupdate",
+  "hello-pepr-finalize-update",
+  "hello-pepr-finalize-update-opt-out",
+  "hello-pepr-finalize-delete",
+];
+
+// Clears pepr.dev/finalizer from any leftover ConfigMap in the test
+// namespaces so namespace termination can't block cleanup. Without this,
+// any CM whose Finalize callback didn't fire (or returned false) keeps
+// its namespace stuck Terminating and afterAll hangs to its timeout.
+async function stripFinalizers(): Promise<void> {
+  for (const ns of TEST_NAMESPACES) {
+    let cms;
+    try {
+      cms = await K8s(kind.ConfigMap).InNamespace(ns).Get();
+    } catch (e) {
+      if (e.status === 404) continue;
+      throw e;
+    }
+    for (const cm of cms.items) {
+      if (!cm.metadata?.finalizers?.includes(FINALIZER)) continue;
+      await K8s(kind.ConfigMap, {
+        namespace: ns,
+        name: cm.metadata!.name!,
+      }).Patch([{ op: "replace", path: "/metadata/finalizers", value: [] }]);
+    }
+  }
+}
+
 describe("finalize.ts", () => {
   beforeAll(async () => await moduleUp(3), mins(4));
   afterAll(async () => {
+    await stripFinalizers();
     await clean(trc);
     await moduleDown();
   }, mins(2));

--- a/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
+++ b/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
@@ -66,13 +66,75 @@ async function stripPeprSystemFinalizers(): Promise<void> {
   }
 }
 
+// Diagnostic dump: log everything in pepr-system at teardown time so we
+// can identify what's actually holding the namespace in Terminating.
+// Runs right before moduleDown(). Best-effort — never throws.
+async function dumpPeprSystem(): Promise<void> {
+  const ns = "pepr-system";
+  console.log(`[diag] === pepr-system teardown snapshot ===`);
+  try {
+    const got = await K8s(kind.Namespace).Get(ns);
+    console.log(
+      `[diag] namespace phase=${got.status?.phase} conditions=${JSON.stringify(
+        got.status?.conditions ?? [],
+      )} finalizers=${JSON.stringify(got.spec?.finalizers ?? [])}`,
+    );
+  } catch (e) {
+    console.log(`[diag] namespace Get failed: status=${e.status}`);
+  }
+
+  const kinds: Array<[string, any]> = [
+    ["ConfigMap", kind.ConfigMap],
+    ["Secret", kind.Secret],
+    ["Pod", kind.Pod],
+    ["Service", kind.Service],
+    ["Deployment", kind.Deployment],
+    ["ServiceAccount", kind.ServiceAccount],
+  ];
+  for (const [label, k] of kinds) {
+    try {
+      const list = await K8s(k).InNamespace(ns).Get();
+      for (const obj of list.items) {
+        const fins = obj.metadata?.finalizers ?? [];
+        const dt = obj.metadata?.deletionTimestamp;
+        console.log(
+          `[diag] ${label}/${obj.metadata?.name} finalizers=${JSON.stringify(fins)} deletionTimestamp=${dt ?? "none"}`,
+        );
+      }
+    } catch (e) {
+      console.log(`[diag] ${label} list failed: status=${e.status}`);
+    }
+  }
+  console.log(`[diag] === end snapshot ===`);
+}
+
+// Bound moduleDown() so afterAll can complete even if pepr-system stays
+// stuck Terminating. The CI job's k3d cluster is destroyed when the job
+// ends, so leaving residual Pepr artifacts is harmless. NOT the same as
+// raising vitest's hookTimeout — that would just wait longer for the
+// same hang; this gives up on the wait and lets the hook exit cleanly.
+async function moduleDownBounded(budgetSecs: number): Promise<void> {
+  const result = await Promise.race([
+    moduleDown().then(() => "done" as const),
+    new Promise<"timeout">(resolve =>
+      setTimeout(() => resolve("timeout"), budgetSecs * 1000),
+    ),
+  ]);
+  if (result === "timeout") {
+    console.warn(
+      `[diag] moduleDown() exceeded ${budgetSecs}s; proceeding so afterAll can complete`,
+    );
+  }
+}
+
 describe("finalize.ts", () => {
   beforeAll(async () => await moduleUp(3), mins(4));
   afterAll(async () => {
     await stripFinalizers();
     await clean(trc);
     await stripPeprSystemFinalizers();
-    await moduleDown();
+    await dumpPeprSystem();
+    await moduleDownBounded(45);
   }, mins(2));
 
   describe("create", () => {

--- a/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
+++ b/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
@@ -6,12 +6,10 @@ import { moduleUp, moduleDown, untilLogged, logs } from "helpers/src/pepr";
 import { clean } from "helpers/src/cluster";
 import { K8s, kind } from "pepr";
 import { KubernetesObject } from "kubernetes-fluent-client";
-import cfg from "../package.json";
 
 const trc = new TestRunCfg(__filename);
 
 const FINALIZER = "pepr.dev/finalizer";
-const PEPR_WEBHOOK_NAME = `pepr-${cfg.pepr.uuid}`;
 const TEST_NAMESPACES = [
   "hello-pepr-finalize-create",
   "hello-pepr-finalize-createorupdate",
@@ -43,22 +41,27 @@ async function stripFinalizers(): Promise<void> {
   }
 }
 
-// Pepr's MutatingWebhookConfiguration matches Namespace operations. The
-// shared moduleDown() helper deletes the pepr-system namespace before
-// removing the webhook configs, so kube-apiserver tries to call a webhook
-// whose backing service is being torn down with the namespace; with
-// failurePolicy: Fail the deletion deadlocks until the hook times out.
-// Removing the webhook configs first lets pepr-system terminate cleanly;
-// moduleDown's later 404-tolerant deletes are no-ops.
-async function removePeprWebhooks(): Promise<void> {
-  for (const k of [
-    kind.ValidatingWebhookConfiguration,
-    kind.MutatingWebhookConfiguration,
-  ]) {
+// Pepr persists its own state in pepr-system (ConfigMaps/Secrets named
+// pepr-<uuid>-*) with finalizers it removes during graceful shutdown.
+// In test teardown the controller is killed before it can drain those
+// finalizers, so pepr-system stays in Terminating and moduleDown's
+// `untilTrue(() => gone(...))` waits forever. Clearing finalizers here
+// lets the namespace terminate immediately.
+async function stripPeprSystemFinalizers(): Promise<void> {
+  const ns = "pepr-system";
+  for (const k of [kind.ConfigMap, kind.Secret]) {
+    let items;
     try {
-      await K8s(k).Delete(PEPR_WEBHOOK_NAME);
+      items = (await K8s(k).InNamespace(ns).Get()).items;
     } catch (e) {
-      if (e.status !== 404) throw e;
+      if (e.status === 404) continue;
+      throw e;
+    }
+    for (const obj of items) {
+      if (!obj.metadata?.finalizers?.length) continue;
+      await K8s(k, { namespace: ns, name: obj.metadata!.name! }).Patch([
+        { op: "replace", path: "/metadata/finalizers", value: [] },
+      ]);
     }
   }
 }
@@ -68,7 +71,7 @@ describe("finalize.ts", () => {
   afterAll(async () => {
     await stripFinalizers();
     await clean(trc);
-    await removePeprWebhooks();
+    await stripPeprSystemFinalizers();
     await moduleDown();
   }, mins(2));
 

--- a/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
+++ b/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
@@ -6,10 +6,12 @@ import { moduleUp, moduleDown, untilLogged, logs } from "helpers/src/pepr";
 import { clean } from "helpers/src/cluster";
 import { K8s, kind } from "pepr";
 import { KubernetesObject } from "kubernetes-fluent-client";
+import cfg from "../package.json";
 
 const trc = new TestRunCfg(__filename);
 
 const FINALIZER = "pepr.dev/finalizer";
+const PEPR_WEBHOOK_NAME = `pepr-${cfg.pepr.uuid}`;
 const TEST_NAMESPACES = [
   "hello-pepr-finalize-create",
   "hello-pepr-finalize-createorupdate",
@@ -41,11 +43,32 @@ async function stripFinalizers(): Promise<void> {
   }
 }
 
+// Pepr's MutatingWebhookConfiguration matches Namespace operations. The
+// shared moduleDown() helper deletes the pepr-system namespace before
+// removing the webhook configs, so kube-apiserver tries to call a webhook
+// whose backing service is being torn down with the namespace; with
+// failurePolicy: Fail the deletion deadlocks until the hook times out.
+// Removing the webhook configs first lets pepr-system terminate cleanly;
+// moduleDown's later 404-tolerant deletes are no-ops.
+async function removePeprWebhooks(): Promise<void> {
+  for (const k of [
+    kind.ValidatingWebhookConfiguration,
+    kind.MutatingWebhookConfiguration,
+  ]) {
+    try {
+      await K8s(k).Delete(PEPR_WEBHOOK_NAME);
+    } catch (e) {
+      if (e.status !== 404) throw e;
+    }
+  }
+}
+
 describe("finalize.ts", () => {
   beforeAll(async () => await moduleUp(3), mins(4));
   afterAll(async () => {
     await stripFinalizers();
     await clean(trc);
+    await removePeprWebhooks();
     await moduleDown();
   }, mins(2));
 

--- a/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
+++ b/hello-pepr-finalize/capabilities/finalize.e2e.test.ts
@@ -133,11 +133,22 @@ describe("finalize.ts", () => {
     await stripFinalizers();
     await clean(trc);
     await stripPeprSystemFinalizers();
-    await moduleDownBounded(45);
-    // Dump AFTER moduleDown timed out — pepr-system should now be in
-    // Terminating phase with status.conditions naming the actual blocker
-    // (NamespaceContentRemaining, NamespaceFinalizersRemaining, etc.).
+
+    // Delete pepr-system ourselves so we can dump it mid-Terminating —
+    // status.conditions populate within a few seconds and name the
+    // actual blocker (NamespaceContentRemaining etc.). Doing this
+    // before moduleDown also avoids the cascading CRD/webhook deletes
+    // that destabilize apiserver discovery (status=400 on subsequent
+    // KFC calls, observed in the prior CI run).
+    try {
+      await K8s(kind.Namespace).Delete("pepr-system");
+    } catch (e) {
+      if (e.status !== 404) throw e;
+    }
+    await new Promise(r => setTimeout(r, 5000));
     await dumpPeprSystem();
+
+    await moduleDownBounded(45);
   }, mins(2));
 
   describe("create", () => {


### PR DESCRIPTION
## Summary

`hello-pepr-finalize` e2e chronically failed with `Hook timed out in 120000ms` on the `afterAll` cleanup despite all 5 `it(...)` tests passing. This PR makes the teardown deterministic so CI is reliable.

## Final fix

1. **`stripFinalizers()`** — clear `pepr.dev/finalizer` from any ConfigMap in the five test namespaces before `clean(trc)`. Defensive: prevents `clean`'s namespace deletion from blocking on a CM whose `Finalize` callback didn't fire (the `update.opt-out` scenario is the deliberate case; flaky reconciles in the others reproduce it).
2. **`stripPeprSystemFinalizers()`** — same defensive pass for `pepr-system`'s ConfigMaps and Secrets, in case Pepr's own state-store resources keep a finalizer through teardown.
3. **`moduleDownBounded(45)`** — `Promise.race` `moduleDown()` against a 45-second budget. If it doesn't finish, log a warning and let `afterAll` exit. The CI job's k3d cluster is destroyed at job end, so a partially-completed `moduleDown` is harmless. This is **not** the same as raising `hookTimeout` — that would just wait longer for the same hang; bounding here gives up on the wait so the hook exits cleanly.

## How we got here (lessons learned)

The investigation took four wrong guesses before the right framing. Each guess was driven by a plausible hypothesis that the CI logs ultimately falsified.

| Attempt | Hypothesis | Outcome |
| --- | --- | --- |
| 1 | Test-namespace ConfigMaps keep `pepr.dev/finalizer` after `update.opt-out` | Helped `clean()` finish in 18s but the hook still timed out — proved the hang is **after** `clean` |
| 2 | `moduleDown` deletes `pepr-system` before removing webhook configs → webhook deadlock on the dying Pepr service | Same 102s silence after `clean` — webhook removal had no effect |
| 3 | Pepr's own state in `pepr-system` (`pepr-<uuid>-*` ConfigMaps/Secrets) keeps finalizers the controller can't drain during shutdown | Stripping those changed nothing — same hang |
| 4 | Whatever it is, instrument it: dump `pepr-system` post-`moduleDown` timeout | All dump calls returned `status=400` — `moduleDown`'s cascading CRD/webhook deletes destabilize apiserver discovery |

That false-negative-then-instrument loop is the lesson. **Stop guessing once two hypotheses miss; add diagnostics instead.** The first diag run (pre-`moduleDown`) showed `pepr-system` totally clean; the second (post-timeout) showed apiserver in a transient state. So I moved the dump to fire 5s after a manual `Delete(pepr-system)`, before `moduleDown`'s broader cleanup ran.

The mid-Terminating snapshot from a clean CI run (`d047b7d`, job `81987321514`):

```text
[diag] === pepr-system teardown snapshot ===
[diag] namespace phase=Terminating conditions=[] finalizers=["kubernetes"]
[diag] ConfigMap/kube-root-ca.crt finalizers=[] deletionTimestamp=none
[diag] Secret/pepr-…-api-path finalizers=[] deletionTimestamp=none
[diag] Secret/pepr-…-module   finalizers=[] deletionTimestamp=none
[diag] Secret/pepr-…-tls      finalizers=[] deletionTimestamp=none
[diag] Pod/pepr-…-2mcx7        finalizers=[] deletionTimestamp=2026-06-17T19:53:28Z
[diag] Pod/pepr-…-dxtfs        finalizers=[] deletionTimestamp=2026-06-17T19:53:28Z
[diag] Pod/pepr-…-watcher-g4pz2 finalizers=[] deletionTimestamp=2026-06-17T19:53:28Z
[diag] Service/pepr-…           finalizers=[] deletionTimestamp=none
[diag] Service/pepr-…-watcher   finalizers=[] deletionTimestamp=none
[diag] Deployment/pepr-…         finalizers=[] deletionTimestamp=none
[diag] Deployment/pepr-…-watcher finalizers=[] deletionTimestamp=none
[diag] ServiceAccount/default    finalizers=[] deletionTimestamp=none
[diag] ServiceAccount/pepr-…     finalizers=[] deletionTimestamp=none
[diag] === end snapshot ===
moduleDown() exceeded 45s; proceeding so afterAll can complete
```

**Key reading:** `conditions=[]` is empty. K8s does not name any blocker (no `NamespaceContentRemaining`, no `NamespaceFinalizersRemaining`). No resource we enumerate carries a finalizer or pending `deletionTimestamp` that would explain the wait. There is no specific finalizer to strip — `pepr-system` just takes longer than 45s to fully terminate on a constrained k3d node. That's why guesses 1–3 all missed: they were all assuming a finalizer-strip would fix it.

The bounded `moduleDown` is therefore the *actual* fix, not a workaround for a missing strip. The two `strip*` helpers are kept as cheap defensive measures.

## Follow-ups (not in this PR)

- Shared-helper change: `_helpers/src/pepr.ts:moduleDown()` could remove webhook configs before deleting `pepr-system` (the order-of-operations point from attempt 2 is still likely *better*, just not the chronic-hang cause). Or it could time-bound its own `untilTrue` waits so every module benefits.
- Enumerate more kinds (Endpoints, EndpointSlices, Lease, Role, RoleBinding, ReplicaSet) in a deeper investigation if anyone wants to chase the root cause of slow k3d namespace termination.

## Test plan

- [ ] CI green on this PR (was chronically red).
- [ ] Re-run the E2E job multiple times to confirm the chronic flake is gone.
- [ ] Verify the 5 existing `it(...)` assertions still pass.