### PR TITLE
fix(helpers): resolve pepr@latest once per test run to avoid redundant downloads

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 24
+          cache: "npm"
 
       - name: create matrix
         run: |
@@ -68,6 +69,7 @@ jobs:
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 24
+          cache: "npm"
 
       - name: install pepr-excellent-examples deps
         run: |

--- a/_helpers/dev/cli.mts
+++ b/_helpers/dev/cli.mts
@@ -117,7 +117,18 @@ program.command('test')
       throw new Error(`Failed to run npm install in ${peprExcellentExamplesRepo}. Check package.json and package-lock.json. Error: ${err.message}`);
     }
 
-    printTestInfo() 
+    // Resolve the pepr spec exactly once per run. The concrete spec is exported
+    // as PEPR_SPEC and inherited by the spawned vitest child, so every downstream
+    // `npx` call (build/deploy/version/init) reuses the cached package instead of
+    // re-resolving the `pepr@latest` dist-tag and re-downloading each time.
+    if (process.env.PEPR_PACKAGE) {
+      process.env.PEPR_SPEC = `file:${process.env.PEPR_PACKAGE}`;
+    } else {
+      const version = execSync(`npm view pepr@latest version`).toString().trim();
+      process.env.PEPR_SPEC = `pepr@${version}`;
+    }
+
+    printTestInfo()
   })
   .action(async ({suite, passthru}) => {
     try{
@@ -143,8 +154,9 @@ function printTestInfo() {
     if (process.env.PEPR_PACKAGE) {
       console.log(`Pepr Build under test: ${execSync(`shasum ${process.env.PEPR_PACKAGE}`).toString()}`);
     } else {
-      const peprVersion = execSync(`npx --yes ${getPeprAlias()} --version`).toString();
-      console.log(`Pepr Version under test: ${peprVersion}`);
+      // PEPR_SPEC was resolved once in preAction ("pepr@<version>"); reuse it
+      // rather than shelling out to `npx` again just to read the version.
+      console.log(`Pepr Version under test: ${process.env.PEPR_SPEC}`);
     }
     if (process.env.PEPR_IMAGE) {
       console.log(`Pepr Image under test: ${execSync(`docker inspect --format="{{.Id}} {{.RepoTags}}" ${process.env.PEPR_IMAGE}`).toString()}`);

--- a/_helpers/src/pepr.ts
+++ b/_helpers/src/pepr.ts
@@ -94,10 +94,22 @@ export async function untilLogged(needle: string | ((log: string) => boolean), c
 }
 
 export function getPeprAlias(): string {
+  // PEPR_SPEC is the spec resolved once per run (e.g. "pepr@1.2.3" or "file:...").
+  // Preferring it lets every downstream `npx` call reuse the cached package
+  // instead of re-resolving the `pepr@latest` dist-tag (and re-downloading).
+  if (process.env.PEPR_SPEC) {
+    return process.env.PEPR_SPEC;
+  }
   return process.env.PEPR_PACKAGE ? `file:${process.env.PEPR_PACKAGE}` : "pepr@latest";
 }
 
 export async function peprVersion(): Promise<string> {
+  // A resolved spec (set once per run) already carries the exact version, so
+  // skip the extra `npx pepr --version` round-trip.
+  if (process.env.PEPR_SPEC?.startsWith("pepr@")) {
+    return process.env.PEPR_SPEC.slice("pepr@".length);
+  }
+
   let version: string = "";
   if (getPeprAlias().startsWith("pepr")) {
     // determine npx pepr@version from workspace root

--- a/_helpers/src/pepr.unit.test.ts
+++ b/_helpers/src/pepr.unit.test.ts
@@ -1,6 +1,56 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import * as sut from "./pepr";
 
+describe("getPeprAlias()", () => {
+  let saved: { PEPR_SPEC?: string; PEPR_PACKAGE?: string };
+
+  beforeEach(() => {
+    saved = { PEPR_SPEC: process.env.PEPR_SPEC, PEPR_PACKAGE: process.env.PEPR_PACKAGE };
+    delete process.env.PEPR_SPEC;
+    delete process.env.PEPR_PACKAGE;
+  });
+
+  afterEach(() => {
+    process.env.PEPR_SPEC = saved.PEPR_SPEC;
+    process.env.PEPR_PACKAGE = saved.PEPR_PACKAGE;
+    if (saved.PEPR_SPEC === undefined) delete process.env.PEPR_SPEC;
+    if (saved.PEPR_PACKAGE === undefined) delete process.env.PEPR_PACKAGE;
+  });
+
+  it("prefers PEPR_SPEC when set (resolved-once spec)", () => {
+    process.env.PEPR_SPEC = "pepr@1.2.3";
+    process.env.PEPR_PACKAGE = "/tmp/pepr.tgz";
+    expect(sut.getPeprAlias()).toBe("pepr@1.2.3");
+  });
+
+  it("falls back to file:PEPR_PACKAGE when PEPR_SPEC is unset", () => {
+    process.env.PEPR_PACKAGE = "/tmp/pepr.tgz";
+    expect(sut.getPeprAlias()).toBe("file:/tmp/pepr.tgz");
+  });
+
+  it("defaults to pepr@latest when nothing is set", () => {
+    expect(sut.getPeprAlias()).toBe("pepr@latest");
+  });
+});
+
+describe("peprVersion()", () => {
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env.PEPR_SPEC;
+  });
+
+  afterEach(() => {
+    process.env.PEPR_SPEC = saved;
+    if (saved === undefined) delete process.env.PEPR_SPEC;
+  });
+
+  it("returns the version from a resolved PEPR_SPEC without shelling out", async () => {
+    process.env.PEPR_SPEC = "pepr@1.2.3";
+    await expect(sut.peprVersion()).resolves.toBe("1.2.3");
+  });
+});
+
 describe("sift()", () => {
   let mockLog, mockErr;
 


### PR DESCRIPTION
## Problem

When the E2E suite runs, Pepr is fetched from the npm registry far more often than necessary. For **each** module's `test:e2e`, the helper code shelled out to `npx --yes pepr@latest ...` up to **four** times:

1. `_helpers/dev/cli.mts` → `printTestInfo()`: `npx --yes ${getPeprAlias()} --version`
2. `_helpers/src/pepr.ts` → `peprVersion()`: `npx pepr --version`
3. `_helpers/src/pepr.ts` → `moduleBuild()`: `npx --yes ${getPeprAlias()} build`
4. `_helpers/src/pepr.ts` → `moduleUp()` deploy: `npx --yes ${getPeprAlias()} deploy`
   (plus `pepr.e2e.test.ts` uses `npx --yes ${getPeprAlias()} init`)

Because `getPeprAlias()` returned the **dist-tag** `pepr@latest`, every call forced npx to re-resolve `latest → version` against the registry and, with `--yes`, tended to re-fetch rather than reuse cache. The CI matrix fans ~30 modules across separate runners with up to 3 retry attempts each, multiplying the waste. `setup-node` in the E2E job also had no npm caching.

## Change

- **Resolve the pepr spec once per run.** `cli.mts`'s `test` preAction now resolves `pepr@latest` to a concrete version a single time (`npm view pepr@latest version`) and exports it as `PEPR_SPEC` (a `pepr@<version>` or `file:` spec) before spawning vitest. The spawned child inherits it.
- **`getPeprAlias()` prefers `PEPR_SPEC`**, so downstream `npx --yes ${getPeprAlias()}` calls reference a concrete version and hit the npm cache instead of re-resolving/re-downloading.
- **`peprVersion()` / `printTestInfo()`** reuse the resolved version instead of shelling out again.
- **Enable `cache: "npm"`** on both `setup-node` steps in `.github/workflows/e2e.yaml`.

Latest tracking is preserved — the dist-tag is still resolved fresh on every run; it's just resolved once instead of ~4 times.

**Net effect:** per module, Pepr registry interactions drop from ~4 dist-tag re-resolutions to 1 resolve + 1 cached tarball download.

## Scope notes

- Only changes how Pepr is **run**, not how it's **installed/pinned** — the `peprPins.ts` rewrite/restore mechanism and workspace `pepr` pins are untouched, so `--local-package`/`--custom-package` dev-build flows are preserved (they flow through the same `PEPR_SPEC=file:...` path).
- `pepr deploy` controller **image** pulls into k3d are a separate concern and out of scope.

## Testing

- `npm run --workspace helpers test:unit` — added coverage for `getPeprAlias()` precedence (`PEPR_SPEC` → `file:PEPR_PACKAGE` → `pepr@latest`) and the `peprVersion()` short-circuit; all pepr unit tests pass.
- End-to-end (build/deploy against a k3d cluster) best confirmed by CI on this PR.